### PR TITLE
Support Log4J 2 as backend

### DIFF
--- a/log4j/src/main/java/de/holisticon/util/tracee/backend/log4j/Log4jTraceeBackendProvider.java
+++ b/log4j/src/main/java/de/holisticon/util/tracee/backend/log4j/Log4jTraceeBackendProvider.java
@@ -7,7 +7,7 @@ import de.holisticon.util.tracee.spi.TraceeBackendProvider;
 import java.util.Set;
 
 /**
- * @author Daniel
+ * @author Daniel Wegener (Holisticon AG)
  */
 public class Log4jTraceeBackendProvider implements TraceeBackendProvider {
 

--- a/log4j2/README.md
+++ b/log4j2/README.md
@@ -1,0 +1,5 @@
+> This document contains documentation for the tracee-log4j2 module. Click [here](/README.md) to get an overview that TracEE is about.
+
+# tracee-log4j2
+
+Backend implementation for [log4j2 (2.0-rc1+)](http://logging.apache.org/log4j/2.x/)

--- a/log4j2/pom.xml
+++ b/log4j2/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>de.holisticon.util.tracee.backend</groupId>
+    <artifactId>tracee-log4j2</artifactId>
+    <packaging>bundle</packaging>
+
+    <parent>
+        <groupId>de.holisticon.util.tracee</groupId>
+        <artifactId>tracee-parent</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <name>tracee-log4j2</name>
+    <description>Please refer to https://github.com/holisticon/tracee.</description>
+
+    <dependencies>
+        <dependency>
+            <artifactId>tracee-core</artifactId>
+            <groupId>de.holisticon.util.tracee</groupId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
+</project>

--- a/log4j2/src/main/java/de/holisticon/util/tracee/backend/log4j2/Log4J2TraceeLogger.java
+++ b/log4j2/src/main/java/de/holisticon/util/tracee/backend/log4j2/Log4J2TraceeLogger.java
@@ -1,0 +1,55 @@
+package de.holisticon.util.tracee.backend.log4j2;
+
+import de.holisticon.util.tracee.TraceeLogger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * TraceeLogger Abstraction for Log4J2.
+ *
+ * @author Daniel Wegener (Holisticon AG)
+ */
+
+final class Log4J2TraceeLogger implements TraceeLogger {
+
+	private final Logger logger;
+
+	public Log4J2TraceeLogger(Logger logger) {
+		this.logger = logger;
+	}
+
+	public void debug(final Object message) {
+		logger.debug(message);
+	}
+
+	public void debug(final Object message, final Throwable t) {
+		logger.debug(message, t);
+	}
+
+	public void error(final Object message) {
+		logger.error(message);
+	}
+
+	public void error(final Object message, final Throwable t) {
+		logger.error(message, t);
+	}
+
+	public void info(final Object message) {
+		logger.info(message);
+	}
+
+	public void info(final Object message, final Throwable t) {
+		logger.info(message, t);
+	}
+
+	public void warn(final Object message) {
+		logger.warn(message);
+	}
+
+	public void warn(final Object message, final Throwable t) {
+		logger.warn(message, t);
+	}
+
+
+}

--- a/log4j2/src/main/java/de/holisticon/util/tracee/backend/log4j2/Log4j2MdcLikeAdapter.java
+++ b/log4j2/src/main/java/de/holisticon/util/tracee/backend/log4j2/Log4j2MdcLikeAdapter.java
@@ -1,0 +1,38 @@
+package de.holisticon.util.tracee.backend.log4j2;
+
+import de.holisticon.util.tracee.MDCLike;
+import org.apache.logging.log4j.ThreadContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Daniel Wegener (Holisticon AG)
+ */
+class Log4j2MdcLikeAdapter implements MDCLike {
+
+	@Override
+	public boolean containsKey(String key) {
+		return ThreadContext.get(key) != null;
+	}
+
+	@Override
+	public void put(String key, String value) {
+		ThreadContext.put(key, value);
+	}
+
+	@Override
+	public String get(String key) {
+		return ThreadContext.get(key);
+	}
+
+	@Override
+	public void remove(String key) {
+		ThreadContext.remove(key);
+	}
+
+	@Override
+	public Map<String, String> getCopyOfContext() {
+		return new HashMap<String, String>(ThreadContext.getContext());
+	}
+}

--- a/log4j2/src/main/java/de/holisticon/util/tracee/backend/log4j2/Log4j2TraceeBackend.java
+++ b/log4j2/src/main/java/de/holisticon/util/tracee/backend/log4j2/Log4j2TraceeBackend.java
@@ -1,0 +1,31 @@
+package de.holisticon.util.tracee.backend.log4j2;
+
+import de.holisticon.util.tracee.MDCLike;
+import de.holisticon.util.tracee.MDCLikeTraceeBackend;
+import de.holisticon.util.tracee.TraceeLogger;
+import de.holisticon.util.tracee.TraceeLoggerFactory;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.Set;
+
+
+/**
+ * @author Daniel Wegener (Holisticon AG)
+ */
+final class Log4j2TraceeBackend extends MDCLikeTraceeBackend {
+
+	Log4j2TraceeBackend(MDCLike mdcAdapter, ThreadLocal<Set<String>> traceeKeys) {
+		super(mdcAdapter, traceeKeys);
+	}
+
+	@Override
+	public TraceeLoggerFactory getLoggerFactory() {
+		return new TraceeLoggerFactory() {
+			@Override
+			public TraceeLogger getLogger(Class<?> clazz) {
+				return new Log4J2TraceeLogger(LogManager.getLogger(clazz));
+			}
+		};
+	}
+
+}

--- a/log4j2/src/main/java/de/holisticon/util/tracee/backend/log4j2/Log4j2TraceeBackendProvider.java
+++ b/log4j2/src/main/java/de/holisticon/util/tracee/backend/log4j2/Log4j2TraceeBackendProvider.java
@@ -1,0 +1,23 @@
+package de.holisticon.util.tracee.backend.log4j2;
+
+import de.holisticon.util.tracee.ThreadLocalHashSet;
+import de.holisticon.util.tracee.TraceeBackend;
+import de.holisticon.util.tracee.spi.TraceeBackendProvider;
+
+import java.util.Set;
+
+/**
+ * @author Daniel Wegener (Holisticon AG)
+ */
+public class Log4j2TraceeBackendProvider implements TraceeBackendProvider {
+
+	private final Log4j2MdcLikeAdapter log4jMdcLikeAdapter = new Log4j2MdcLikeAdapter();
+	private final ThreadLocal<Set<String>> traceeKeyStore = new ThreadLocalHashSet<String>();
+
+	private final Log4j2TraceeBackend log4jTraceeBackend = new Log4j2TraceeBackend(log4jMdcLikeAdapter, traceeKeyStore);
+
+	@Override
+	public final TraceeBackend provideBackend() {
+		return log4jTraceeBackend;
+	}
+}

--- a/log4j2/src/main/resources/META-INF/services/de.holisticon.util.tracee.spi.TraceeBackendProvider
+++ b/log4j2/src/main/resources/META-INF/services/de.holisticon.util.tracee.spi.TraceeBackendProvider
@@ -1,0 +1,1 @@
+de.holisticon.util.tracee.backend.log4j2.Log4j2TraceeBackendProvider

--- a/log4j2/src/test/java/de/holisticon/util/tracee/backend/log4j2/Log4j2TraceeContextProviderIT.java
+++ b/log4j2/src/test/java/de/holisticon/util/tracee/backend/log4j2/Log4j2TraceeContextProviderIT.java
@@ -1,0 +1,26 @@
+package de.holisticon.util.tracee.backend.log4j2;
+
+import de.holisticon.util.tracee.Tracee;
+import de.holisticon.util.tracee.TraceeBackend;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * @author Daniel Wegener (Holisticon AG)
+ */
+public class Log4j2TraceeContextProviderIT {
+
+    @Test
+    public void testLoadProviderAndStoreToLog4j2ThreadContext() {
+        final TraceeBackend backend = Tracee.getBackend();
+		backend.put("FOO", "BAR");
+        assertThat(ThreadContext.get("FOO"), equalTo("BAR"));
+		backend.remove("FOO");
+		assertThat(ThreadContext.get("FOO"), nullValue());
+    }
+
+}

--- a/log4j2/src/test/java/de/holisticon/util/tracee/backend/log4j2/Log4j2TraceeLoggerTest.java
+++ b/log4j2/src/test/java/de/holisticon/util/tracee/backend/log4j2/Log4j2TraceeLoggerTest.java
@@ -1,0 +1,69 @@
+package de.holisticon.util.tracee.backend.log4j2;
+
+import org.apache.logging.log4j.Logger;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Daniel Wegener (Holisticon AG)
+ */
+public class Log4j2TraceeLoggerTest {
+
+	private static final Object MESSAGE = "TEST";
+	private static final Exception EXCEPTION = new RuntimeException("My exception");
+
+
+	private final Logger mockedLogger = mock(Logger.class);
+	private final Log4J2TraceeLogger UNIT = new Log4J2TraceeLogger(mockedLogger);
+
+	@Test
+	public void logDebugMessageWithLogger() {
+		UNIT.debug(MESSAGE);
+		verify(mockedLogger).debug(MESSAGE);
+	}
+
+	@Test
+	public void logDebugMessageAndExceptionWithLogger() {
+		UNIT.debug(MESSAGE, EXCEPTION);
+		verify(mockedLogger).debug(MESSAGE, EXCEPTION);
+	}
+
+	@Test
+	public void logInfoMessageWithLogger() {
+		UNIT.info(MESSAGE);
+		verify(mockedLogger).info(MESSAGE);
+	}
+
+	@Test
+	public void logInfoMessageAndExceptionWithLogger() {
+		UNIT.info(MESSAGE, EXCEPTION);
+		verify(mockedLogger).info(MESSAGE, EXCEPTION);
+	}
+
+	@Test
+	public void logWarnMessageWithLogger() {
+		UNIT.warn(MESSAGE);
+		verify(mockedLogger).warn(MESSAGE);
+	}
+
+	@Test
+	public void logWarnMessageAndExceptionWithLogger() {
+		UNIT.warn(MESSAGE, EXCEPTION);
+		verify(mockedLogger).warn(MESSAGE, EXCEPTION);
+	}
+
+	@Test
+	public void logErrorMessageWithLogger() {
+		UNIT.error(MESSAGE);
+		verify(mockedLogger).error(MESSAGE);
+	}
+
+	@Test
+	public void logErrorMessageAndExceptionWithLogger() {
+		UNIT.error(MESSAGE, EXCEPTION);
+		verify(mockedLogger).error(MESSAGE, EXCEPTION);
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<!-- backends -->
 		<module>slf4j</module>
 		<module>log4j</module>
+		<module>log4j2</module>
 		<module>jboss-logging</module>
 		<module>threadlocal-store</module>
 
@@ -116,6 +117,7 @@
 		<!-- dependency versions -->
 		<slf4j.version>1.6.6</slf4j.version>
 		<log4j.version>1.2.4</log4j.version>
+		<log4j2.version>2.0-rc1</log4j2.version>
 		<logback.version>0.9.30</logback.version>
 		<gson.version>2.2.4</gson.version>
 		<spring.version>3.0.7.RELEASE</spring.version>
@@ -410,6 +412,18 @@
 				<groupId>log4j</groupId>
 				<version>${log4j.version}</version>
 				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>${log4j2.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>${log4j2.version}</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Create a module tracee-log4j2 that acts as a backend-provider for a log4j2 backend.
