### PR TITLE
Downgrade openejb dependencies

### DIFF
--- a/jaxws/pom.xml
+++ b/jaxws/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.openejb</groupId>
             <artifactId>openejb-cxf</artifactId>
-            <version>4.6.0</version>
+            <version>4.5.2</version>
             <scope>test</scope>
         </dependency>
 		<dependency>

--- a/jms/pom.xml
+++ b/jms/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.openejb</groupId>
             <artifactId>openejb-core</artifactId>
-            <version>4.6.0</version>
+            <version>4.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Resolve #26: Downgrade apache.openejb:openejb-core and org.apache.openejb:openejb-cxf from 4.6.0 to 4.5.2.
