### PR TITLE
Enforcing at least 3.1.0 instead of exactly 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
 						<configuration>
 							<rules>
 								<requireMavenVersion>
-									<version>3.1.0</version>
+									<version>[3.1.0,)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
 									<version>1.6</version>


### PR DESCRIPTION
It's not even on the main page for Downloads anymore. One has to go the version archives. :(
