### PR TITLE
Fix #35: Use stable version of Log4J2 (2.0.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 		<!-- dependency versions -->
 		<slf4j.version>1.6.6</slf4j.version>
 		<log4j.version>1.2.4</log4j.version>
-		<log4j2.version>2.0-rc1</log4j2.version>
+		<log4j2.version>2.0.2</log4j2.version>
 		<logback.version>0.9.30</logback.version>
 		<gson.version>2.2.4</gson.version>
 		<spring.version>3.0.7.RELEASE</spring.version>


### PR DESCRIPTION
Use 2.0.2 of Log4J2 instead of 2.0-rc1
