### PR TITLE
Upgrade Mockito 1.9.5 to 1.10.8 (latest available on central)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 		<!-- versions of test dependencies -->
 		<junit.version>4.11</junit.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<mockito.version>1.9.5</mockito.version>
+		<mockito.version>1.10.8</mockito.version>
 		<powermock.version>1.5.6</powermock.version>
 
 		<!-- dependency versions -->


### PR DESCRIPTION
again - where is the merged change?
