### PR TITLE
Log only Strings instead of generic Objects.

### DIFF
--- a/api/src/main/java/io/tracee/TraceeLogger.java
+++ b/api/src/main/java/io/tracee/TraceeLogger.java
@@ -5,27 +5,27 @@ package io.tracee;
  * It will resolve to the underlying logging system.
  */
 public interface TraceeLogger {
-    void debug(final Object message);
+    void debug(final String message);
 
-    void debug(final Object message, final Throwable t);
+    void debug(final String message, final Throwable t);
 
 	boolean isDebugEnabled();
 
-    void error(final Object message);
+    void error(final String message);
 
-    void error(final Object message, final Throwable t);
+    void error(final String message, final Throwable t);
 
 	boolean isErrorEnabled();
 
-    void info(final Object message);
+    void info(final String message);
 
-    void info(final Object message, final Throwable t);
+    void info(final String message, final Throwable t);
 
 	boolean isInfoEnabled();
 
-    void warn(final Object message);
+    void warn(final String message);
 
-    void warn(final Object message, final Throwable t);
+    void warn(final String message, final Throwable t);
 
 	boolean isWarnEnabled();
 }

--- a/backend/jboss-logging/src/main/java/io/tracee/backend/jbosslogging/JbossLoggingTraceeLogger.java
+++ b/backend/jboss-logging/src/main/java/io/tracee/backend/jbosslogging/JbossLoggingTraceeLogger.java
@@ -14,11 +14,11 @@ final class JbossLoggingTraceeLogger implements TraceeLogger {
         this.logger = logger;
     }
 
-    public void debug(final Object message) {
+    public void debug(final String message) {
         logger.debug(message);
     }
 
-    public void debug(final Object message, final Throwable t) {
+    public void debug(final String message, final Throwable t) {
         logger.debug(message, t);
     }
 
@@ -27,11 +27,11 @@ final class JbossLoggingTraceeLogger implements TraceeLogger {
 		return logger.isDebugEnabled();
 	}
 
-	public void error(final Object message) {
+	public void error(final String message) {
         this.logger.error(message);
     }
 
-    public void error(final Object message, final Throwable t) {
+    public void error(final String message, final Throwable t) {
         logger.error(message, t);
     }
 
@@ -40,11 +40,11 @@ final class JbossLoggingTraceeLogger implements TraceeLogger {
 		return logger.isEnabled(Logger.Level.ERROR);
 	}
 
-    public void info(final Object message) {
+    public void info(final String message) {
         logger.info(message);
     }
 
-    public void info(final Object message, final Throwable t) {
+    public void info(final String message, final Throwable t) {
         logger.info(message, t);
     }
 
@@ -53,11 +53,11 @@ final class JbossLoggingTraceeLogger implements TraceeLogger {
 		return logger.isInfoEnabled();
 	}
 
-    public void warn(final Object message) {
+    public void warn(final String message) {
         logger.warn(message);
     }
 
-    public void warn(final Object message, final Throwable t) {
+    public void warn(final String message, final Throwable t) {
         logger.warn(message, t);
     }
 

--- a/backend/log4j/src/main/java/io/tracee/backend/log4j/Log4jTraceeLogger.java
+++ b/backend/log4j/src/main/java/io/tracee/backend/log4j/Log4jTraceeLogger.java
@@ -15,11 +15,11 @@ final class Log4jTraceeLogger implements TraceeLogger {
 		this.logger = logger;
 	}
 
-	public void debug(final Object message) {
+	public void debug(final String message) {
 		this.logger.debug(message);
 	}
 
-	public void debug(final Object message, final Throwable t) {
+	public void debug(final String message, final Throwable t) {
 		this.logger.debug(message, t);
 	}
 
@@ -28,11 +28,11 @@ final class Log4jTraceeLogger implements TraceeLogger {
 		return logger.isDebugEnabled();
 	}
 
-	public void error(final Object message) {
+	public void error(final String message) {
 		this.logger.error(message);
 	}
 
-	public void error(final Object message, final Throwable t) {
+	public void error(final String message, final Throwable t) {
 		this.logger.error(message, t);
 	}
 
@@ -41,11 +41,11 @@ final class Log4jTraceeLogger implements TraceeLogger {
 		return logger.isEnabledFor(Priority.ERROR);
 	}
 
-	public void info(final Object message) {
+	public void info(final String message) {
 		this.logger.info(message);
 	}
 
-	public void info(final Object message, final Throwable t) {
+	public void info(final String message, final Throwable t) {
 		this.logger.info(message, t);
 	}
 
@@ -54,11 +54,11 @@ final class Log4jTraceeLogger implements TraceeLogger {
 		return logger.isInfoEnabled();
 	}
 
-	public void warn(final Object message) {
+	public void warn(final String message) {
 		this.logger.warn(message);
 	}
 
-	public void warn(final Object message, final Throwable t) {
+	public void warn(final String message, final Throwable t) {
 		this.logger.warn(message, t);
 	}
 

--- a/backend/log4j2/src/main/java/io/tracee/backend/log4j2/Log4J2TraceeLogger.java
+++ b/backend/log4j2/src/main/java/io/tracee/backend/log4j2/Log4J2TraceeLogger.java
@@ -15,11 +15,11 @@ final class Log4J2TraceeLogger implements TraceeLogger {
 		this.logger = logger;
 	}
 
-	public void debug(final Object message) {
+	public void debug(final String message) {
 		logger.debug(message);
 	}
 
-	public void debug(final Object message, final Throwable t) {
+	public void debug(final String message, final Throwable t) {
 		logger.debug(message, t);
 	}
 
@@ -28,11 +28,11 @@ final class Log4J2TraceeLogger implements TraceeLogger {
 		return logger.isDebugEnabled();
 	}
 
-	public void error(final Object message) {
+	public void error(final String message) {
 		logger.error(message);
 	}
 
-	public void error(final Object message, final Throwable t) {
+	public void error(final String message, final Throwable t) {
 		logger.error(message, t);
 	}
 
@@ -41,11 +41,11 @@ final class Log4J2TraceeLogger implements TraceeLogger {
 		return logger.isErrorEnabled();
 	}
 
-	public void info(final Object message) {
+	public void info(final String message) {
 		logger.info(message);
 	}
 
-	public void info(final Object message, final Throwable t) {
+	public void info(final String message, final Throwable t) {
 		logger.info(message, t);
 	}
 
@@ -54,11 +54,11 @@ final class Log4J2TraceeLogger implements TraceeLogger {
 		return logger.isInfoEnabled();
 	}
 
-	public void warn(final Object message) {
+	public void warn(final String message) {
 		logger.warn(message);
 	}
 
-	public void warn(final Object message, final Throwable t) {
+	public void warn(final String message, final Throwable t) {
 		logger.warn(message, t);
 	}
 

--- a/backend/log4j2/src/test/java/io/tracee/backend/log4j2/Log4j2TraceeLoggerTest.java
+++ b/backend/log4j2/src/test/java/io/tracee/backend/log4j2/Log4j2TraceeLoggerTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 
 public class Log4j2TraceeLoggerTest {
 
-	private static final Object MESSAGE = "TEST";
+	private static final String MESSAGE = "TEST";
 	private static final Exception EXCEPTION = new RuntimeException("My exception");
 
 	private final Logger mockedLogger = mock(Logger.class);

--- a/backend/slf4j/src/main/java/io/tracee/backend/slf4j/Slf4jTraceeLogger.java
+++ b/backend/slf4j/src/main/java/io/tracee/backend/slf4j/Slf4jTraceeLogger.java
@@ -19,11 +19,11 @@ final class Slf4jTraceeLogger implements TraceeLogger {
 		this.logger = logger;
 	}
 
-    public void debug(Object message) {
+    public void debug(String message) {
         logger.debug(nullsafeString(message));
     }
 
-    public void debug(Object message, Throwable t) {
+    public void debug(String message, Throwable t) {
         logger.debug(nullsafeString(message), t);
     }
 
@@ -32,11 +32,11 @@ final class Slf4jTraceeLogger implements TraceeLogger {
 		return logger.isDebugEnabled();
 	}
 
-	public void error(Object message) {
+	public void error(String message) {
         logger.error(nullsafeString(message));
     }
 
-    public void error(Object message, Throwable t) {
+    public void error(String message, Throwable t) {
         logger.error(nullsafeString(message), t);
     }
 
@@ -45,11 +45,11 @@ final class Slf4jTraceeLogger implements TraceeLogger {
 		return logger.isErrorEnabled();
 	}
 
-    public void info(Object message) {
+    public void info(String message) {
         logger.info(nullsafeString(message));
     }
 
-    public void info(Object message, Throwable t) {
+    public void info(String message, Throwable t) {
         logger.info(nullsafeString(message), t);
     }
 
@@ -58,11 +58,11 @@ final class Slf4jTraceeLogger implements TraceeLogger {
 		return logger.isInfoEnabled();
 	}
 
-    public void warn(Object message) {
+    public void warn(String message) {
         logger.warn(nullsafeString(message));
     }
 
-	public void warn(Object message, Throwable t) {
+	public void warn(String message, Throwable t) {
         logger.warn(nullsafeString(message), t);
     }
 
@@ -71,7 +71,7 @@ final class Slf4jTraceeLogger implements TraceeLogger {
 		return logger.isWarnEnabled();
 	}
 
-	private String nullsafeString(Object message) {
-		return message != null ? message.toString() : "";
+	private String nullsafeString(String message) {
+		return message != null ? message : "";
 	}
 }

--- a/backend/threadlocal-store/src/main/java/io/tracee/backend/threadlocalstore/ThreadLocalTraceeLogger.java
+++ b/backend/threadlocal-store/src/main/java/io/tracee/backend/threadlocalstore/ThreadLocalTraceeLogger.java
@@ -18,11 +18,11 @@ final class ThreadLocalTraceeLogger implements TraceeLogger {
     }
 
 
-    private void createLogEntry(final LEVEL level, final Object message) {
+    private void createLogEntry(final LEVEL level, final String message) {
         this.createLogEntry(level, message, null);
     }
 
-    private void createLogEntry(final LEVEL level, final Object message, final Throwable t) {
+    private void createLogEntry(final LEVEL level, final String message, final Throwable t) {
 		System.err.println(buildLogString(level, message));
         if (t != null) {
             t.printStackTrace(System.err);
@@ -30,16 +30,16 @@ final class ThreadLocalTraceeLogger implements TraceeLogger {
         }
     }
 
-	String buildLogString(LEVEL level, Object message) {
+	String buildLogString(LEVEL level, String message) {
 		return level.name()	+ " - (" + this.clazz.getCanonicalName() + ") :"
-					+ (message != null ? message.toString() : "");
+					+ (message != null ? message : "");
 	}
 
-	public void debug(final Object message) {
+	public void debug(final String message) {
         // drop debug message
     }
 
-    public void debug(final Object message, final Throwable t) {
+    public void debug(final String message, final Throwable t) {
         // drop debug message
     }
 
@@ -48,11 +48,11 @@ final class ThreadLocalTraceeLogger implements TraceeLogger {
 		return false;
 	}
 
-	public void error(final Object message) {
+	public void error(final String message) {
         this.createLogEntry(LEVEL.ERROR, message);
     }
 
-    public void error(final Object message, final Throwable t) {
+    public void error(final String message, final Throwable t) {
         this.createLogEntry(LEVEL.ERROR, message, t);
     }
 
@@ -61,11 +61,11 @@ final class ThreadLocalTraceeLogger implements TraceeLogger {
 		return true;
 	}
 
-    public void info(final Object message) {
+    public void info(final String message) {
         // drop info message
     }
 
-    public void info(final Object message, final Throwable t) {
+    public void info(final String message, final Throwable t) {
         // drop info message
     }
 
@@ -74,11 +74,11 @@ final class ThreadLocalTraceeLogger implements TraceeLogger {
 		return false;
 	}
 
-    public void warn(final Object message) {
+    public void warn(final String message) {
         this.createLogEntry(LEVEL.WARN, message);
     }
 
-    public void warn(final Object message, final Throwable t) {
+    public void warn(final String message, final Throwable t) {
         this.createLogEntry(LEVEL.WARN, message, t);
     }
 

--- a/testhelper/src/main/java/io/tracee/NoopTraceeLoggerFactory.java
+++ b/testhelper/src/main/java/io/tracee/NoopTraceeLoggerFactory.java
@@ -9,12 +9,12 @@ public class NoopTraceeLoggerFactory implements TraceeLoggerFactory {
 	public final TraceeLogger getLogger(Class<?> clazz) {
 		return new TraceeLogger() {
 			@Override
-			public void debug(Object message) {
+			public void debug(String message) {
 
 			}
 
 			@Override
-			public void debug(Object message, Throwable t) {
+			public void debug(String message, Throwable t) {
 
 			}
 
@@ -24,12 +24,12 @@ public class NoopTraceeLoggerFactory implements TraceeLoggerFactory {
 			}
 
 			@Override
-			public void error(Object message) {
+			public void error(String message) {
 
 			}
 
 			@Override
-			public void error(Object message, Throwable t) {
+			public void error(String message, Throwable t) {
 
 			}
 
@@ -39,12 +39,12 @@ public class NoopTraceeLoggerFactory implements TraceeLoggerFactory {
 			}
 
 			@Override
-			public void info(Object message) {
+			public void info(String message) {
 
 			}
 
 			@Override
-			public void info(Object message, Throwable t) {
+			public void info(String message, Throwable t) {
 
 			}
 
@@ -54,12 +54,12 @@ public class NoopTraceeLoggerFactory implements TraceeLoggerFactory {
 			}
 
 			@Override
-			public void warn(Object message) {
+			public void warn(String message) {
 
 			}
 
 			@Override
-			public void warn(Object message, Throwable t) {
+			public void warn(String message, Throwable t) {
 
 			}
 


### PR DESCRIPTION
Two reasons for this:
- Less errorprone for the programmer - not all objects implement the toString-method
- Easier for us: java.util.Logging is working with Strings only (I'm currently workin' on)

In my opinion it's safe to change this API because users of TracEE doesn't use these abstraction. - They log directly to their implementation.
