### PR TITLE
Add more junit tests to JaxWS binding

### DIFF
--- a/binding/jaxws/src/test/java/io/tracee/jaxws/client/TraceeClientHandlerTest.java
+++ b/binding/jaxws/src/test/java/io/tracee/jaxws/client/TraceeClientHandlerTest.java
@@ -1,0 +1,113 @@
+package io.tracee.jaxws.client;
+
+import io.tracee.SimpleTraceeBackend;
+import io.tracee.TraceeBackend;
+import io.tracee.TraceeConstants;
+import io.tracee.transport.SoapHeaderTransport;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPEnvelope;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPMessage;
+import javax.xml.soap.SOAPPart;
+import javax.xml.ws.handler.soap.SOAPMessageContext;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TraceeClientHandlerTest {
+
+	private TraceeBackend backend = spy(SimpleTraceeBackend.createNonLoggingAllPermittingBackend());
+
+	private final TraceeClientHandler unit = new TraceeClientHandler(backend);
+	private SOAPMessageContext messageContext = mock(SOAPMessageContext.class);
+
+	private SOAPMessage message;
+
+	@Before
+	public void setup() throws SOAPException {
+		message = spy(MessageFactory.newInstance().createMessage());
+		when(messageContext.getMessage()).thenReturn(message);
+	}
+
+	@Test
+	public void faultsShouldBeHandledWithoutMessageInteraction() throws SOAPException {
+		assertThat(unit.handleFault(messageContext), is(true));
+		verify(message, never()).getSOAPHeader();
+	}
+
+	@Test
+	public void skipProcessingWithoutErrorIfNoTpicHeaderIsInMessage() throws SOAPException {
+		unit.handleIncoming(messageContext);
+		assertThat(backend.isEmpty(), is(true));
+	}
+
+	@Test
+	public void skipProcessingWithoutErrorIfNoSoapHeaderIsInMessage() throws SOAPException {
+		when(message.getSOAPHeader()).thenReturn(null);
+		unit.handleIncoming(messageContext);
+		assertThat(backend.isEmpty(), is(true));
+	}
+
+	@Test
+	public void catchExceptionOnReadTpicHeader() throws SOAPException {
+		when(message.getSOAPHeader()).thenThrow(SOAPException.class);
+		unit.handleIncoming(messageContext);
+		assertThat(backend.isEmpty(), is(true));
+	}
+
+	@Test
+	public void readSoapHeaderIntoToBackend() throws SOAPException, JAXBException {
+		final Map<String, String> context = new HashMap<String, String>();
+		context.put("abc", "123");
+
+		new SoapHeaderTransport().renderSoapHeader(context, message.getSOAPHeader());
+		when(messageContext.getMessage()).thenReturn(message);
+
+		unit.handleIncoming(messageContext);
+		assertThat(backend.copyToMap(), hasEntry("abc", "123"));
+	}
+
+	@Test
+	public void addSoapHeaderIfNooneIsOnMessage() throws SOAPException {
+		backend.put("abcd", "12");
+		when(message.getSOAPHeader()).thenReturn(null);
+		when(message.getSOAPPart()).thenReturn(mock(SOAPPart.class));
+		final SOAPEnvelope envelope = mock(SOAPEnvelope.class);
+		when(message.getSOAPPart().getEnvelope()).thenReturn(envelope);
+
+		unit.handleOutgoing(messageContext);
+		verify(envelope).addHeader();
+	}
+
+	@Test
+	public void renderBackendToSoapHeader() throws SOAPException {
+		backend.put("my header", "Wow!");
+		unit.handleOutgoing(messageContext);
+		final NodeList tpicElements = message.getSOAPHeader().getElementsByTagNameNS(TraceeConstants.SOAP_HEADER_NAMESPACE, TraceeConstants.SOAP_HEADER_NAME);
+		assertThat(tpicElements.getLength(), is(1));
+		final Node tpicEntry = tpicElements.item(0).getChildNodes().item(0);
+		assertThat(tpicEntry.getLocalName(), is("entry"));
+		assertThat(tpicEntry.getAttributes().getNamedItem("key").getNodeValue(), is("my header"));
+		assertThat(tpicEntry.getChildNodes().item(0).getNodeValue(), is("Wow!"));
+	}
+
+	@Test
+	public void skipProcessingIfBackendIsEmpty() throws SOAPException {
+		unit.handleOutgoing(messageContext);
+		verify(message, never()).getSOAPHeader();
+	}
+}

--- a/binding/jaxws/src/test/java/io/tracee/jaxws/container/TraceeServerHandlerTest.java
+++ b/binding/jaxws/src/test/java/io/tracee/jaxws/container/TraceeServerHandlerTest.java
@@ -2,11 +2,14 @@ package io.tracee.jaxws.container;
 
 import io.tracee.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
+import io.tracee.TraceeConstants;
 import io.tracee.transport.SoapHeaderTransport;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.xml.bind.JAXBException;
+import javax.xml.soap.MessageFactory;
 import javax.xml.soap.SOAPEnvelope;
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPHeader;
@@ -15,8 +18,14 @@ import javax.xml.soap.SOAPPart;
 import javax.xml.ws.handler.soap.SOAPMessageContext;
 import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,36 +35,83 @@ public class TraceeServerHandlerTest {
 	private final TraceeBackend backend = spy(SimpleTraceeBackend.createNonLoggingAllPermittingBackend());
 	private final SoapHeaderTransport soapHeaderTransport = mock(SoapHeaderTransport.class);
 	private final TraceeServerHandler unit = new TraceeServerHandler(backend, soapHeaderTransport);
-	private final SOAPMessageContext soapMessageContext = mock(SOAPMessageContext.class);
-	private final SOAPMessage soapMessage = mock(SOAPMessage.class);
-	private final SOAPPart soapPart = mock(SOAPPart.class);
-	private final SOAPEnvelope soapEnvelope = mock(SOAPEnvelope.class);
-	private final SOAPHeader soapHeader = mock(SOAPHeader.class);
+	private SOAPMessageContext messageContext = mock(SOAPMessageContext.class);
+
+	private SOAPMessage message;
 
 	@Before
-	public void setUp() throws SOAPException {
-		when(soapMessageContext.getMessage()).thenReturn(soapMessage);
-		when(soapMessage.getSOAPPart()).thenReturn(soapPart);
-		when(soapPart.getEnvelope()).thenReturn(soapEnvelope);
-		when(soapEnvelope.getHeader()).thenReturn(soapHeader);
+	public void setup() throws SOAPException {
+		message = spy(MessageFactory.newInstance().createMessage());
+		when(messageContext.getMessage()).thenReturn(message);
 	}
 
 	@Test
-	public void testHandleIncoming() throws JAXBException {
-		when(soapHeaderTransport.parseSoapHeader(eq(soapHeader))).thenReturn(Collections.singletonMap("FOO","BAR"));
-		unit.handleIncoming(soapMessageContext);
+	public void testHandleIncoming() throws JAXBException, SOAPException {
+		when(soapHeaderTransport.parseSoapHeader(eq(message.getSOAPHeader()))).thenReturn(Collections.singletonMap("FOO", "BAR"));
+		unit.handleIncoming(messageContext);
 		verify(backend).putAll(Collections.singletonMap("FOO", "BAR"));
 	}
 
 	@Test
+	public void generateRequestIdEvenWhenIncomingMessageCouldntParsed() throws SOAPException {
+		when(message.getSOAPHeader()).thenThrow(SOAPException.class);
+		unit.handleIncoming(messageContext);
+		assertThat(backend.copyToMap(), hasKey(TraceeConstants.REQUEST_ID_KEY));
+	}
+
+	@Test
 	public void testHandleOutgoing() throws SOAPException, JAXBException {
-		unit.handleOutgoing(soapMessageContext);
-		verify(soapHeaderTransport).renderSoapHeader(eq(backend.copyToMap()), eq(soapHeader));
+		backend.put("John", "Boy");
+		final SOAPHeader soapHeader = message.getSOAPHeader();
+		unit.handleOutgoing(messageContext);
+		verify(soapHeaderTransport).renderSoapHeader(anyMapOf(String.class, String.class), eq(soapHeader));
+	}
+
+	@Test
+	public void handleOutgoingIfBackendIsNotEmpty() throws SOAPException, JAXBException {
+		backend.put("John", "Boy");
+		final SOAPHeader header = message.getSOAPHeader();
+		unit.handleOutgoing(messageContext);
+		verify(soapHeaderTransport).renderSoapHeader(anyMapOf(String.class, String.class), eq(header));
+	}
+
+	@Test
+	public void doNotHAndleOutgoingIfBackendIsEmpty() throws SOAPException, JAXBException {
+		final SOAPHeader header = message.getSOAPHeader();
+		unit.handleOutgoing(messageContext);
+		verify(soapHeaderTransport, never()).renderSoapHeader(anyMapOf(String.class, String.class), eq(header));
+	}
+
+	@Test
+	public void catchExceptionIfOutgoingTpicHeaderIsNotRenderable() throws SOAPException {
+		when(message.getSOAPHeader()).thenThrow(SOAPException.class);
+		unit.handleOutgoing(messageContext);
+		assertThat(backend.isEmpty(), is(true));
+	}
+
+	@Test
+	public void addSoapHeaderIfNooneIsOnMessage() throws SOAPException {
+		backend.put("abcd", "12");
+		when(message.getSOAPHeader()).thenReturn(null);
+		when(message.getSOAPPart()).thenReturn(mock(SOAPPart.class));
+		final SOAPEnvelope envelope = mock(SOAPEnvelope.class);
+		when(message.getSOAPPart().getEnvelope()).thenReturn(envelope);
+
+		unit.handleOutgoing(messageContext);
+		verify(envelope).addHeader();
 	}
 
 	@Test
 	public void testHandleOutgoingHasCalledClearInTheEnd() throws SOAPException {
-		unit.handleOutgoing(soapMessageContext);
+		unit.handleOutgoing(messageContext);
 		verify(backend).clear();
+	}
+
+	@Test
+	public void handleFaults() throws SOAPException {
+		backend.put("hey", "12");
+		final boolean handleFault = unit.handleFault(messageContext);
+		assertThat(handleFault, is(true));
+		verify(message).getSOAPHeader();
 	}
 }


### PR DESCRIPTION
Raise the test coverage - see #34 .
Found and fixed one issue: Generate always the requestId - even when an exception occurs.
