### PR TITLE
Fix #64 and refactor cxf itests such that they use SimpleBackends

### DIFF
--- a/binding/cxf/src/main/java/io/tracee/cxf/interceptor/AbstractTraceeOutInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/cxf/interceptor/AbstractTraceeOutInterceptor.java
@@ -23,9 +23,9 @@ import java.util.Map;
 
 abstract class AbstractTraceeOutInterceptor extends AbstractPhaseInterceptor<Message> {
 
-	private final TraceeLogger LOGGER;
+	private final TraceeLogger logger;
 
-	private final TraceeBackend backend;
+	protected final TraceeBackend backend;
 
 	private final HttpHeaderTransport httpSerializer;
 	private final TraceeFilterConfiguration.Channel channel;
@@ -36,7 +36,7 @@ abstract class AbstractTraceeOutInterceptor extends AbstractPhaseInterceptor<Mes
 		super(phase);
 		this.channel = channel;
 		this.backend = backend;
-		LOGGER = backend.getLoggerFactory().getLogger(this.getClass());
+		logger = backend.getLoggerFactory().getLogger(this.getClass());
 		this.profile = profile;
 		this.httpSerializer = new HttpHeaderTransport(backend.getLoggerFactory());
 	}
@@ -48,7 +48,7 @@ abstract class AbstractTraceeOutInterceptor extends AbstractPhaseInterceptor<Mes
 			if (!backend.isEmpty() && filterConfiguration.shouldProcessContext(channel)) {
                 final Map<String, String> filteredParams = filterConfiguration.filterDeniedParams(backend.copyToMap(), channel);
 
-				LOGGER.debug("Interceptor handles message!");
+				logger.debug("Interceptor handles message!");
                 if (message instanceof SoapMessage) {
                     final SoapMessage soapMessage = (SoapMessage) message;
 
@@ -73,8 +73,8 @@ abstract class AbstractTraceeOutInterceptor extends AbstractPhaseInterceptor<Mes
 					new JAXBDataBinding(TpicMap.class));
 			soapMessage.getHeaders().add(tpicHeader);
 		} catch (JAXBException e) {
-			LOGGER.warn("Error occured during TracEE soap header creation: " + e.getMessage());
-			LOGGER.debug("Detailed exception", e);
+			logger.warn("Error occured during TracEE soap header creation: " + e.getMessage());
+			logger.debug("Detailed exception", e);
 		}
 
 	}

--- a/binding/cxf/src/main/java/io/tracee/cxf/interceptor/TraceeResponseOutInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/cxf/interceptor/TraceeResponseOutInterceptor.java
@@ -1,6 +1,7 @@
 package io.tracee.cxf.interceptor;
 
 import io.tracee.TraceeBackend;
+import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.Phase;
@@ -15,6 +16,14 @@ public class TraceeResponseOutInterceptor extends AbstractTraceeOutInterceptor {
 
 	public TraceeResponseOutInterceptor(TraceeBackend backend, String profile) {
 		super(Phase.USER_LOGICAL, OutgoingResponse, backend, profile);
+	}
+
+	@Override
+	public void handleMessage(Message message) throws Fault {
+		super.handleMessage(message);
+		if (shouldHandleMessage(message)) {
+			backend.clear();
+		}
 	}
 
 	@Override

--- a/binding/cxf/src/test/java/io/tracee/cxf/AbstractConnectionITHelper.java
+++ b/binding/cxf/src/test/java/io/tracee/cxf/AbstractConnectionITHelper.java
@@ -1,28 +1,21 @@
 package io.tracee.cxf;
 
-import io.tracee.Tracee;
+import io.tracee.SimpleTraceeBackend;
 import io.tracee.cxf.testSoapService.HelloWorldTestServiceImpl;
-import org.apache.cxf.Bus;
 import org.apache.cxf.bus.CXFBusFactory;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
-import org.apache.cxf.interceptor.Fault;
-import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.jaxws.JaxWsServerFactoryBean;
-import org.apache.cxf.message.Message;
-import org.apache.cxf.phase.AbstractPhaseInterceptor;
-import org.apache.cxf.phase.Phase;
 import org.junit.After;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Random;
 
 public abstract class AbstractConnectionITHelper {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractConnectionITHelper.class);
 
 	protected Server server;
+
+	protected final SimpleTraceeBackend serverBackend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+	protected final SimpleTraceeBackend clientBackend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
 
 	protected String endpointAddress;
 
@@ -40,34 +33,9 @@ public abstract class AbstractConnectionITHelper {
 		JaxWsServerFactoryBean serverFactoryBean = new JaxWsServerFactoryBean();
 		serverFactoryBean.setServiceClass(HelloWorldTestServiceImpl.class);
 		serverFactoryBean.setAddress(endpointAddress);
-		serverFactoryBean.setServiceBean(new HelloWorldTestServiceImpl());
+		serverFactoryBean.setServiceBean(new HelloWorldTestServiceImpl(serverBackend));
 		serverFactoryBean.setBus(CXFBusFactory.getDefaultBus());
 		return serverFactoryBean;
-	}
-
-	/**
-	 * Simple Feature to reset the TraceeBackend to keep sure, that the context is really transferred between HTTP.
-	 * Otherwise it could be still in place (same thread) or copied (new generated thread).
-	 */
-	class ResetBackendFeature extends AbstractFeature {
-		@Override
-		protected void initializeProvider(InterceptorProvider provider, Bus bus)  {
-			final ResetBackendInterceptor interceptor = new ResetBackendInterceptor();
-			provider.getOutInterceptors().add(interceptor);
-			provider.getInInterceptors().add(interceptor);
-		}
-	}
-
-	class ResetBackendInterceptor extends AbstractPhaseInterceptor<Message> {
-		public ResetBackendInterceptor() {
-			super(Phase.SEND_ENDING);
-		}
-
-		@Override
-		public void handleMessage(Message message) throws Fault {
-			LOGGER.info("CLEARING BACKEND!!");
-			Tracee.getBackend().clear();
-		}
 	}
 
 	/*

--- a/binding/cxf/src/test/java/io/tracee/cxf/interceptor/OutgoingSoapMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/cxf/interceptor/OutgoingSoapMessageTest.java
@@ -14,6 +14,10 @@ import org.junit.Test;
 
 import javax.xml.bind.JAXBException;
 
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -21,17 +25,10 @@ import static org.junit.Assert.assertThat;
 
 public class OutgoingSoapMessageTest {
 
-	private static final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
-
-	private Interceptor<Message> outInterceptor;
-
+	private final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+	private final Interceptor<Message> outInterceptor = new TraceeResponseOutInterceptor(backend);
 	private final SoapMessage soapMessage = new SoapMessage(new MessageImpl());
 
-	@Before
-	public void onSetup() throws Exception {
-		backend.clear();
-		outInterceptor = new TraceeResponseOutInterceptor(backend);
-	}
 
 	@Test
 	public void shouldHandleSoapMessageWithoutSoapHeader() {
@@ -42,11 +39,20 @@ public class OutgoingSoapMessageTest {
 	@Test
 	public void shouldAddHeaderWithDataBindingToSoapMessage() throws JAXBException {
 		backend.put("mySoapContext", "mySoapContextValue");
+		final Map<String,String> expectedHeaderFields = backend.copyToMap();
 		outInterceptor.handleMessage(soapMessage);
 
 		final Header tpicHeader = soapMessage.getHeaders().get(0);
 		assertThat(tpicHeader.getName(), is(TraceeConstants.SOAP_HEADER_QNAME));
 		assertThat(tpicHeader.getObject(), instanceOf(TpicMap.class));
-		assertThat(((TpicMap) tpicHeader.getObject()), is(TpicMap.wrap(backend.copyToMap())));
+		assertThat(((TpicMap) tpicHeader.getObject()), is(TpicMap.wrap(expectedHeaderFields)));
 	}
+
+	@Test
+	public void shouldClearTheBackendAfterHandleMessage() throws JAXBException {
+		backend.put("foo", "bar");
+		outInterceptor.handleMessage(soapMessage);
+		assertThat(backend.copyToMap(), equalTo(Collections.<String,String>emptyMap()));
+	}
+
 }

--- a/binding/cxf/src/test/java/io/tracee/cxf/testSoapService/HelloWorldTestServiceImpl.java
+++ b/binding/cxf/src/test/java/io/tracee/cxf/testSoapService/HelloWorldTestServiceImpl.java
@@ -1,16 +1,23 @@
 package io.tracee.cxf.testSoapService;
 
-
-import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class HelloWorldTestServiceImpl implements HelloWorldTestService {
+
+	private final TraceeBackend backend;
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(HelloWorldTestServiceImpl.class);
+
+	public HelloWorldTestServiceImpl(TraceeBackend backend) {
+		this.backend = backend;
+	}
+
 	public String sayHelloWorld(String firstName) {
-		Tracee.getBackend().put(TEST_KEY, "accepted");
+		backend.put(TEST_KEY, "accepted");
 		LOGGER.info("sayHelloWorld called with firstname '{}'", firstName);
-		return "Hello " + firstName + " || requestId was " + Tracee.getBackend().get(TraceeConstants.REQUEST_ID_KEY);
+		return "Hello " + firstName + " || requestId was " + backend.get(TraceeConstants.REQUEST_ID_KEY);
 	}
 }

--- a/binding/jaxws/src/main/java/io/tracee/jaxws/container/TraceeServerHandler.java
+++ b/binding/jaxws/src/main/java/io/tracee/jaxws/container/TraceeServerHandler.java
@@ -23,7 +23,7 @@ public class TraceeServerHandler extends AbstractTraceeHandler {
 		this(Tracee.getBackend(), new SoapHeaderTransport());
 	}
 
-	TraceeServerHandler(TraceeBackend traceeBackend, SoapHeaderTransport soapHeaderTransport) {
+	public TraceeServerHandler(TraceeBackend traceeBackend, SoapHeaderTransport soapHeaderTransport) {
 		super(traceeBackend);
 		this.transportSerialization = soapHeaderTransport;
 		traceeLogger = traceeBackend.getLoggerFactory().getLogger(TraceeServerHandler.class);


### PR DESCRIPTION
Refactoring of cxf itests such that they use SimpleBackends, each for the client and the server endpoint (also: clean instances per test).
