### PR TITLE
Move ApacheCXF feature to root of cxf package

### DIFF
--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/TraceeCxfFeature.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/TraceeCxfFeature.java
@@ -1,4 +1,4 @@
-package io.tracee.binding.cxf.client;
+package io.tracee.binding.cxf;
 
 import io.tracee.Tracee;
 import io.tracee.TraceeBackend;

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/CxfClientToCxfServerIT.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/CxfClientToCxfServerIT.java
@@ -1,7 +1,6 @@
 package io.tracee.binding.cxf;
 
 import io.tracee.TraceeConstants;
-import io.tracee.binding.cxf.client.TraceeCxfFeature;
 import io.tracee.binding.cxf.testSoapService.HelloWorldTestService;
 import org.apache.cxf.bus.CXFBusFactory;
 import org.apache.cxf.feature.LoggingFeature;

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/CxfClientToJaxwsServerIT.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/CxfClientToJaxwsServerIT.java
@@ -1,7 +1,6 @@
 package io.tracee.binding.cxf;
 
 import io.tracee.*;
-import io.tracee.binding.cxf.client.TraceeCxfFeature;
 import io.tracee.binding.cxf.testSoapService.HelloWorldTestService;
 import io.tracee.binding.jaxws.client.TraceeClientHandler;
 import org.apache.cxf.feature.LoggingFeature;

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/JaxwsClientToCxfServerIT.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/JaxwsClientToCxfServerIT.java
@@ -1,7 +1,6 @@
 package io.tracee.binding.cxf;
 
 import io.tracee.TraceeConstants;
-import io.tracee.binding.cxf.client.TraceeCxfFeature;
 import io.tracee.binding.cxf.testSoapService.HelloWorldTestService;
 import io.tracee.binding.jaxws.client.TraceeClientHandler;
 import org.apache.cxf.Bus;

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/TraceeCxfFeatureTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/TraceeCxfFeatureTest.java
@@ -1,4 +1,4 @@
-package io.tracee.binding.cxf.client;
+package io.tracee.binding.cxf;
 
 import io.tracee.SimpleTraceeBackend;
 import org.apache.cxf.Bus;


### PR DESCRIPTION
Remove the middle package `client` for the CXF-Feature. This feature is able to handle clients and server implementations.