### PR TITLE
accept traceRequestId and traceSessionId from request parameters

### DIFF
--- a/api/src/main/java/io/tracee/TraceeBackend.java
+++ b/api/src/main/java/io/tracee/TraceeBackend.java
@@ -74,4 +74,8 @@ public interface TraceeBackend {
      * @param key ignored if {@code null}
      */
     void remove(String key);
+
+	String getRequestId();
+	String getSessionId();
+	String getConversationId();
 }

--- a/api/src/main/java/io/tracee/TraceeConstants.java
+++ b/api/src/main/java/io/tracee/TraceeConstants.java
@@ -13,6 +13,7 @@ public final class TraceeConstants {
 
     public static final String SESSION_ID_KEY = "traceeSessionId";
     public static final String REQUEST_ID_KEY = "traceeRequestId";
+	public static final String CONVERSATION_ID_KEY = "traceeConversationId";
 
 	public static final String SOAP_HEADER_NAME = "tpic";
 	public static final String SOAP_HEADER_NAMESPACE = "http://tracee.io/tpic/1.0";

--- a/api/src/main/java/io/tracee/configuration/TraceeFilterConfiguration.java
+++ b/api/src/main/java/io/tracee/configuration/TraceeFilterConfiguration.java
@@ -42,6 +42,10 @@ public interface TraceeFilterConfiguration {
 
 	boolean shouldGenerateSessionId();
 
+	boolean shouldGenerateConversationId();
+
+	int generatedConversationIdLength();
+
 	/**
 	 * @return a desired non-negative length of the generated session identifiers. If it returns <code>0</code>, no session identifiers should be generated.
 	 */

--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeRequestInInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeRequestInInterceptor.java
@@ -24,6 +24,7 @@ public class TraceeRequestInInterceptor extends AbstractTraceeInInterceptor {
 		super.handleMessage(message);
 		if (shouldHandleMessage(message)) {
 			Utilities.generateRequestIdIfNecessary(backend);
+			Utilities.generateConversationIdIfNecessary(backend);
 		}
 	}
 

--- a/binding/jaxrs2/src/main/java/io/tracee/binding/jaxrs2/TraceeContainerRequestFilter.java
+++ b/binding/jaxrs2/src/main/java/io/tracee/binding/jaxrs2/TraceeContainerRequestFilter.java
@@ -43,5 +43,6 @@ public class TraceeContainerRequestFilter implements ContainerRequestFilter {
 		}
 
 		Utilities.generateRequestIdIfNecessary(backend);
+		Utilities.generateConversationIdIfNecessary(backend);
 	}
 }

--- a/binding/jaxws/src/main/java/io/tracee/binding/jaxws/TraceeServerHandler.java
+++ b/binding/jaxws/src/main/java/io/tracee/binding/jaxws/TraceeServerHandler.java
@@ -43,6 +43,7 @@ public class TraceeServerHandler extends AbstractTraceeHandler {
 		}
 
 		Utilities.generateRequestIdIfNecessary(traceeBackend);
+		Utilities.generateConversationIdIfNecessary(traceeBackend);
 	}
 
 	protected final void handleOutgoing(SOAPMessageContext context) {

--- a/binding/servlet/src/main/java/io/tracee/binding/servlet/TraceeServletRequestListener.java
+++ b/binding/servlet/src/main/java/io/tracee/binding/servlet/TraceeServletRequestListener.java
@@ -78,6 +78,7 @@ public final class TraceeServletRequestListener implements ServletRequestListene
 		}
 
 		Utilities.generateRequestIdIfNecessary(backend);
+		Utilities.generateConversationIdIfNecessary(backend);
 
 		final HttpSession session = request.getSession(false);
 		if (session != null) {

--- a/binding/servlet/src/test/java/io/tracee/binding/servlet/TraceeServletRequestListenerTest.java
+++ b/binding/servlet/src/test/java/io/tracee/binding/servlet/TraceeServletRequestListenerTest.java
@@ -5,9 +5,11 @@ import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
 import io.tracee.configuration.TraceeFilterConfiguration;
 import io.tracee.transport.HttpHeaderTransport;
+import io.tracee.transport.HttpRequestParameterTransport;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -20,20 +22,29 @@ import javax.servlet.http.HttpSession;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-
+import java.util.Map;
 
 import static io.tracee.TraceeConstants.REQUEST_ID_KEY;
 import static io.tracee.TraceeConstants.SESSION_ID_KEY;
 import static io.tracee.configuration.TraceeFilterConfiguration.Channel.IncomingRequest;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.atLeastOnce;
 
 public class TraceeServletRequestListenerTest {
 
 	private final HttpHeaderTransport transportSerialization = new HttpHeaderTransport(new NoopTraceeLoggerFactory());
+	private final HttpRequestParameterTransport httpRequestParameterTransport = new HttpRequestParameterTransport(new NoopTraceeLoggerFactory());
 	private final TraceeBackend backend = Mockito.mock(TraceeBackend.class);
-	private final TraceeServletRequestListener unit = new TraceeServletRequestListener(backend, transportSerialization);
+	private final TraceeServletRequestListener unit = new TraceeServletRequestListener(backend, transportSerialization, httpRequestParameterTransport);
 	private final HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);
 	private final TraceeFilterConfiguration configuration = Mockito.mock(TraceeFilterConfiguration.class);
 
@@ -77,6 +88,59 @@ public class TraceeServletRequestListenerTest {
 		unit.requestInitialized(wrapToEvent(httpServletRequest));
 
 		verify(backend, atLeastOnce()).putAll(Mockito.eq(new HashMap<String, String>() {{ put(REQUEST_ID_KEY,"123"); }} ));
+	}
+
+	@Test
+	public void testAcceptIncomingRequestAndSessionIdFromParameter() throws Exception {
+		when(configuration.shouldGenerateRequestId()).thenReturn(false);
+		when(configuration.shouldProcessContext(IncomingRequest)).thenReturn(true);
+		when(configuration.filterDeniedParams(anyMapOf(String.class, String.class), any(TraceeFilterConfiguration.Channel.class))).thenAnswer(new Answer<Object>() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				return invocation.getArguments()[0];
+			}
+		});
+		when(httpServletRequest.getParameterMap()).thenReturn(
+				new HashMap<String, String[]>() {{
+					put(REQUEST_ID_KEY, new String[]{"124"});
+					put(SESSION_ID_KEY, new String[]{"987"});
+				}});
+
+		unit.requestInitialized(wrapToEvent(httpServletRequest));
+
+		verify(backend, atLeastOnce()).putAll(Mockito.eq(new HashMap<String, String>() {{
+			put(REQUEST_ID_KEY, "124");
+			put(SESSION_ID_KEY, "987");
+		}}));
+	}
+
+	@Test
+	public void testHeaderRequestAndSessionIdOverwriteRequestAndSessionIdFromParameter() throws Exception {
+		when(configuration.shouldGenerateRequestId()).thenReturn(false);
+		when(configuration.shouldProcessContext(IncomingRequest)).thenReturn(true);
+		when(configuration.filterDeniedParams(anyMapOf(String.class, String.class), any(TraceeFilterConfiguration.Channel.class))).thenAnswer(new Answer<Object>() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				return invocation.getArguments()[0];
+			}
+		});
+		when(httpServletRequest.getParameterMap()).thenReturn(
+				new HashMap<String, String[]>() {{
+					put(REQUEST_ID_KEY, new String[]{"124"});
+					put(SESSION_ID_KEY, new String[]{"16061981"});
+				}});
+		when(httpServletRequest.getHeaders(TraceeConstants.HTTP_HEADER_NAME)).thenReturn(Collections.enumeration(
+				Arrays.asList(REQUEST_ID_KEY + "=123", SESSION_ID_KEY + "=08081988")));
+
+		ArgumentCaptor<Map> argument = ArgumentCaptor.forClass(Map.class);
+
+		unit.requestInitialized(wrapToEvent(httpServletRequest));
+
+		verify(backend, atLeastOnce()).putAll(argument.capture());
+		assertThat(argument.getAllValues(), hasItem(new HashMap<String, String>() {{
+			put(REQUEST_ID_KEY, "123");
+			put(SESSION_ID_KEY, "08081988");
+		}}));
 	}
 
 	@Test

--- a/binding/springmvc/src/main/java/io/tracee/binding/springmvc/TraceeInterceptor.java
+++ b/binding/springmvc/src/main/java/io/tracee/binding/springmvc/TraceeInterceptor.java
@@ -65,6 +65,7 @@ public final class TraceeInterceptor implements HandlerInterceptor {
 		}
 
 		Utilities.generateRequestIdIfNecessary(backend);
+		Utilities.generateConversationIdIfNecessary(backend);
 
 		final HttpSession session = request.getSession(false);
 		if (session != null) {

--- a/core/src/main/java/io/tracee/MDCLikeTraceeBackend.java
+++ b/core/src/main/java/io/tracee/MDCLikeTraceeBackend.java
@@ -139,4 +139,15 @@ public abstract class MDCLikeTraceeBackend implements TraceeBackend {
 
 	protected abstract void removeFromMdc(String key);
 
+	public String getRequestId() {
+		return get(TraceeConstants.REQUEST_ID_KEY);
+	}
+
+	public String getSessionId() {
+		return get(TraceeConstants.SESSION_ID_KEY);
+	}
+
+	public String getConversationId() {
+		return get(TraceeConstants.CONVERSATION_ID_KEY);
+	}
 }

--- a/core/src/main/java/io/tracee/Utilities.java
+++ b/core/src/main/java/io/tracee/Utilities.java
@@ -1,7 +1,5 @@
 package io.tracee;
 
-import io.tracee.configuration.TraceeFilterConfiguration;
-
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.security.MessageDigest;
@@ -82,5 +80,17 @@ public final class Utilities {
 		if (backend != null && !backend.containsKey(TraceeConstants.SESSION_ID_KEY) && backend.getConfiguration().shouldGenerateSessionId()) {
 			backend.put(TraceeConstants.SESSION_ID_KEY, Utilities.createAlphanumericHash(sessionId, backend.getConfiguration().generatedSessionIdLength()));
 		}
+	}
+
+	/**
+	 * Generate conversation id hash if it doesn't exist in TraceeBackend and configuration asks for one
+	 *
+	 * @param backend Currently used TraceeBackend
+	 */
+	public static String generateConversationIdIfNecessary(final TraceeBackend backend) {
+		if (backend != null && !backend.containsKey(TraceeConstants.CONVERSATION_ID_KEY) && backend.getConfiguration().shouldGenerateConversationId()) {
+			backend.put(TraceeConstants.CONVERSATION_ID_KEY, Utilities.createRandomAlphanumeric(backend.getConfiguration().generatedConversationIdLength()));
+		}
+		return backend != null ? backend.get(TraceeConstants.CONVERSATION_ID_KEY) : null;
 	}
 }

--- a/core/src/main/java/io/tracee/configuration/PropertiesBasedTraceeFilterConfiguration.java
+++ b/core/src/main/java/io/tracee/configuration/PropertiesBasedTraceeFilterConfiguration.java
@@ -2,7 +2,12 @@ package io.tracee.configuration;
 
 import io.tracee.Utilities;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
 
 public final class PropertiesBasedTraceeFilterConfiguration implements TraceeFilterConfiguration {
 
@@ -11,6 +16,7 @@ public final class PropertiesBasedTraceeFilterConfiguration implements TraceeFil
 	static final String DEFAULT_PROFILE_PREFIX = DEFAULT_PROFILE + ".";
 	public static final String GENERATE_REQUEST_ID = "requestIdLength";
 	public static final String GENERATE_SESSION_ID = "sessionIdLength";
+	public static final String GENERATE_CONVERSATION_ID = "conversationIdLength";
 
 	private final PropertyChain propertyChain;
 	private final String profileName;
@@ -27,8 +33,9 @@ public final class PropertiesBasedTraceeFilterConfiguration implements TraceeFil
 	private String getProfiledOrDefaultProperty(String propertyName) {
 		if (profileName != null) {
 			final String profiledProperty = propertyChain.getProperty(TRACEE_CONFIG_PREFIX + profileName + '.' + propertyName);
-			if (profiledProperty != null)
+			if (profiledProperty != null) {
 				return profiledProperty;
+			}
 		}
 		return propertyChain.getProperty(TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + propertyName);
 	}
@@ -62,6 +69,16 @@ public final class PropertiesBasedTraceeFilterConfiguration implements TraceeFil
 	}
 
 	@Override
+	public boolean shouldGenerateConversationId() {
+		return generatedConversationIdLength() > 0;
+	}
+
+	@Override
+	public int generatedConversationIdLength() {
+		return parseIntOrZero(getProfiledOrDefaultProperty(GENERATE_CONVERSATION_ID));
+	}
+
+	@Override
 	public int generatedSessionIdLength() {
 		return parseIntOrZero(getProfiledOrDefaultProperty(GENERATE_SESSION_ID));
 	}
@@ -87,8 +104,9 @@ public final class PropertiesBasedTraceeFilterConfiguration implements TraceeFil
 
 	private boolean anyPatternMatchesParamName(Iterable<String> patterns, String paramName) {
 		for (String pattern : patterns) {
-			if (patternMatchesParamName(pattern, paramName))
+			if (patternMatchesParamName(pattern, paramName)) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -98,8 +116,9 @@ public final class PropertiesBasedTraceeFilterConfiguration implements TraceeFil
 	}
 
 	private List<String> extractPatterns(String propertyValue) {
-		if (propertyValue == null)
+		if (propertyValue == null) {
 			return Collections.emptyList();
+		}
 
 		final List<String> trimmedPatterns = new ArrayList<String>();
 		final StringTokenizer tokenizer = new StringTokenizer(propertyValue, ",");

--- a/core/src/main/java/io/tracee/transport/HttpRequestParameterTransport.java
+++ b/core/src/main/java/io/tracee/transport/HttpRequestParameterTransport.java
@@ -1,0 +1,39 @@
+package io.tracee.transport;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeConstants;
+import io.tracee.TraceeLogger;
+import io.tracee.TraceeLoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpRequestParameterTransport {
+
+	private final TraceeLogger logger;
+
+	public HttpRequestParameterTransport() {
+		this(Tracee.getBackend().getLoggerFactory());
+	}
+
+	public HttpRequestParameterTransport(TraceeLoggerFactory loggerFactory) {
+		this.logger = loggerFactory.getLogger(HttpRequestParameterTransport.class);
+	}
+
+	public Map<String, String> parse(Map<String, String[]> serializedElements) {
+		final Map<String, String> contextMap = new HashMap<String, String>();
+
+		final String[] requestIdValue = serializedElements.get(TraceeConstants.REQUEST_ID_KEY);
+		if (requestIdValue != null && requestIdValue.length > 0) {
+			contextMap.put(TraceeConstants.REQUEST_ID_KEY, requestIdValue[0]);
+		}
+
+		final String[] sessionIdValue = serializedElements.get(TraceeConstants.SESSION_ID_KEY);
+		if (sessionIdValue != null && sessionIdValue.length > 0) {
+			contextMap.put(TraceeConstants.SESSION_ID_KEY, sessionIdValue[0]);
+		}
+
+		return contextMap;
+	}
+
+}

--- a/core/src/main/java/io/tracee/transport/HttpRequestParameterTransport.java
+++ b/core/src/main/java/io/tracee/transport/HttpRequestParameterTransport.java
@@ -33,6 +33,11 @@ public class HttpRequestParameterTransport {
 			contextMap.put(TraceeConstants.SESSION_ID_KEY, sessionIdValue[0]);
 		}
 
+		final String[] conversationIdValue = serializedElements.get(TraceeConstants.CONVERSATION_ID_KEY);
+		if (conversationIdValue != null && conversationIdValue.length > 0) {
+			contextMap.put(TraceeConstants.CONVERSATION_ID_KEY, conversationIdValue[0]);
+		}
+
 		return contextMap;
 	}
 

--- a/core/src/main/resources/META-INF/tracee.default.properties
+++ b/core/src/main/resources/META-INF/tracee.default.properties
@@ -9,6 +9,7 @@ tracee.default.AsyncDispatch=.*
 tracee.default.AsyncProcess=.*
 tracee.default.requestIdLength=32
 tracee.default.sessionIdLength=32
+tracee.default.conversationIdLength=32
 
 # HideInbound Profile
 # Does not respond with a TracEE-Header in OutgoingResponses.

--- a/core/src/test/java/io/tracee/UtilitiesTest.java
+++ b/core/src/test/java/io/tracee/UtilitiesTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.regex.Pattern;
 
+import static io.tracee.TraceeConstants.CONVERSATION_ID_KEY;
 import static io.tracee.TraceeConstants.REQUEST_ID_KEY;
 import static io.tracee.TraceeConstants.SESSION_ID_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -119,5 +120,26 @@ public class UtilitiesTest {
 		Utilities.generateSessionIdIfNecessary(backend, "123");
 		assertThat(backend.get(SESSION_ID_KEY), equalTo(Utilities.createAlphanumericHash("123",
 				PermitAllTraceeFilterConfiguration.ARBITRARY_NUMBER)));
+	}
+
+	@Test
+	public void ignoreConversationIdGenerationIfBackendIsNull() {
+		Utilities.generateConversationIdIfNecessary(null);
+		assertTrue("No exception occurred", true);
+	}
+
+	@Test
+	public void dontGenerateConversationIdIfPresentInBackend() {
+		final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+		backend.put(CONVERSATION_ID_KEY, "ourTestId");
+		Utilities.generateConversationIdIfNecessary(backend);
+		assertThat(backend.get(CONVERSATION_ID_KEY), is("ourTestId"));
+	}
+
+	@Test
+	public void generateConversationIdIfNotPresentInBackend() {
+		final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+		final String conversationId = Utilities.generateConversationIdIfNecessary(backend);
+		assertThat(backend.get(CONVERSATION_ID_KEY), equalTo(conversationId));
 	}
 }

--- a/testhelper/src/main/java/io/tracee/PermitAllTraceeFilterConfiguration.java
+++ b/testhelper/src/main/java/io/tracee/PermitAllTraceeFilterConfiguration.java
@@ -42,4 +42,14 @@ public class PermitAllTraceeFilterConfiguration implements TraceeFilterConfigura
 	public final int generatedSessionIdLength() {
 		return ARBITRARY_NUMBER;
 	}
+
+	@Override
+	public boolean shouldGenerateConversationId() {
+		return true;
+	}
+
+	@Override
+	public int generatedConversationIdLength() {
+		return ARBITRARY_NUMBER;
+	}
 }

--- a/testhelper/src/main/java/io/tracee/SimpleTraceeBackend.java
+++ b/testhelper/src/main/java/io/tracee/SimpleTraceeBackend.java
@@ -97,4 +97,16 @@ public class SimpleTraceeBackend implements TraceeBackend {
 	public Map<String, String> getValuesBeforeLastClear() {
 		return valuesBeforeLastClear;
 	}
+
+	public String getRequestId() {
+		return get(TraceeConstants.REQUEST_ID_KEY);
+	}
+
+	public String getSessionId() {
+		return get(TraceeConstants.SESSION_ID_KEY);
+	}
+
+	public String getConversationId() {
+		return get(TraceeConstants.CONVERSATION_ID_KEY);
+	}
 }


### PR DESCRIPTION
We need a possibility to transfer traceeRequestId (and maybe traceeSessionId) from one system to another over http-get-request and can only add/modify url parameter in the request.
With this patch tracee should be able to read traceeRequestId and traceeSessionId from requestParameters. 