### PR TITLE
Add shortcut to requestId and sessionId

### DIFF
--- a/api/src/main/java/io/tracee/TraceeBackend.java
+++ b/api/src/main/java/io/tracee/TraceeBackend.java
@@ -74,4 +74,16 @@ public interface TraceeBackend {
      * @param key ignored if {@code null}
      */
     void remove(String key);
+
+	/**
+	 * Shortcut for {@code get(TraceeConstants.REQUEST_ID_KEY)}
+	 * @return The current value for the Key {@code TraceeConstants.REQUEST_ID_KEY} or {@code null} if no value is set.
+	 */
+	String getRequestId();
+
+	/**
+	 * Shortcut for {@code get(TraceeConstants.SESSION_ID_KEY)}
+	 * @return The current value for the Key {@code TraceeConstants.SESSION_ID_KEY} or {@code null} if no value is set.
+	 */
+	String getSessionId();
 }

--- a/core/src/main/java/io/tracee/MDCLikeTraceeBackend.java
+++ b/core/src/main/java/io/tracee/MDCLikeTraceeBackend.java
@@ -96,7 +96,17 @@ public abstract class MDCLikeTraceeBackend implements TraceeBackend {
         }
     }
 
-    /**
+	@Override
+	public String getRequestId() {
+		return get(TraceeConstants.REQUEST_ID_KEY);
+	}
+
+	@Override
+	public String getSessionId() {
+		return get(TraceeConstants.SESSION_ID_KEY);
+	}
+
+	/**
      * Removes all tracee values from the underlying MDC and removes the thread local traceeKeys set.
      */
     @Override

--- a/core/src/test/java/io/tracee/MDCLikeTraceeBackendTest.java
+++ b/core/src/test/java/io/tracee/MDCLikeTraceeBackendTest.java
@@ -143,6 +143,28 @@ public class MDCLikeTraceeBackendTest {
 	}
 
 	@Test
+	public void requestIdShortcutShouldReturnTheRequestIdIfSet() {
+		unit.put(TraceeConstants.REQUEST_ID_KEY, "ourRequestId");
+		assertThat(unit.getRequestId(), is("ourRequestId"));
+	}
+
+	@Test
+	public void requestIdShortcutShouldReturnNullIfNoRequestIdIsSet() {
+		assertThat(unit.getRequestId(), is(nullValue()));
+	}
+
+	@Test
+	public void sessionIdShortcutShouldReturnTheSessionIdIfSet() {
+		unit.put(TraceeConstants.SESSION_ID_KEY, "ourSessionId");
+		assertThat(unit.getSessionId(), is("ourSessionId"));
+	}
+
+	@Test
+	public void sessionIdShortcutShouldReturnNullIfNoSessionIdIsSet() {
+		assertThat(unit.getSessionId(), is(nullValue()));
+	}
+
+	@Test
 	public void containsShouldreturnFalseIfNotInMDC() {
 		assertThat(unit.containsKey("A"), is(false));
 	}

--- a/testhelper/src/main/java/io/tracee/SimpleTraceeBackend.java
+++ b/testhelper/src/main/java/io/tracee/SimpleTraceeBackend.java
@@ -94,6 +94,16 @@ public class SimpleTraceeBackend implements TraceeBackend {
 		backendValues.remove(key);
 	}
 
+	@Override
+	public String getRequestId() {
+		return get(TraceeConstants.REQUEST_ID_KEY);
+	}
+
+	@Override
+	public String getSessionId() {
+		return get(TraceeConstants.SESSION_ID_KEY);
+	}
+
 	public Map<String, String> getValuesBeforeLastClear() {
 		return valuesBeforeLastClear;
 	}


### PR DESCRIPTION
The `TraceeBackend`-Class provides two helper methods. One to retrieve the request-id, one for the session-id. -- of course only if present in the backend.

For example: `Tracee.getBackend().getSessionId()` is just a shortcut for `Tracee.getBackend().get(TraceeConstants.SESSION_ID_KEY)` 