### PR TITLE
Speedup property filtering

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,5 +27,9 @@
 			<groupId>nl.jqno.equalsverifier</groupId>
 			<artifactId>equalsverifier</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.carrotsearch</groupId>
+			<artifactId>junit-benchmarks</artifactId>
+		</dependency>
     </dependencies>
 </project>

--- a/core/src/test/java/io/tracee/configuration/PropertiesBasedTraceeFilterConfigurationBenchmarkTest.java
+++ b/core/src/test/java/io/tracee/configuration/PropertiesBasedTraceeFilterConfigurationBenchmarkTest.java
@@ -1,0 +1,82 @@
+package io.tracee.configuration;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkHistoryChart;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
+import com.carrotsearch.junitbenchmarks.annotation.LabelType;
+import io.tracee.SimpleTraceeBackend;
+import io.tracee.TraceeBackend;
+import io.tracee.TraceeConstants;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@AxisRange(min = 0, max = 5)
+@BenchmarkMethodChart(filePrefix = "benchmark-lists")
+@BenchmarkHistoryChart(labelWith = LabelType.CUSTOM_KEY, maxRuns = 20)
+public class PropertiesBasedTraceeFilterConfigurationBenchmarkTest {
+
+	@Rule
+	public TestRule benchmarkRun = new BenchmarkRule();
+
+	private final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+
+	public static final TraceeFilterConfiguration.Channel CHANNEL = TraceeFilterConfiguration.Channel.IncomingRequest;
+	private PropertiesBasedTraceeFilterConfiguration unit;
+
+	private Map<String, String> propertyMap;
+
+	@Before
+	public void before() throws IOException {
+		final Properties traceeDefaultFileProperties = new TraceePropertiesFileLoader().loadTraceeProperties(TraceePropertiesFileLoader.TRACEE_DEFAULT_PROPERTIES_FILE);
+		final Properties traceeFileProperties = new TraceePropertiesFileLoader().loadTraceeProperties(TraceePropertiesFileLoader.TRACEE_PROPERTIES_FILE);
+		final PropertyChain propertyChain = PropertyChain.build(System.getProperties(), traceeFileProperties, traceeDefaultFileProperties);
+
+		unit = new PropertiesBasedTraceeFilterConfiguration(backend.getLoggerFactory(), propertyChain);
+		generateTestPropertyMap();
+		System.clearProperty(PropertiesBasedTraceeFilterConfiguration.TRACEE_DEFAULT_PROFILE_PREFIX + CHANNEL);
+	}
+
+	private void generateTestPropertyMap() {
+		propertyMap = new HashMap<String, String>();
+		propertyMap.put(TraceeConstants.REQUEST_ID_KEY, "reqID");
+		propertyMap.put(TraceeConstants.SESSION_ID_KEY, "sessID");
+		propertyMap.put("aaa", "AAA");
+		propertyMap.put("bbb", "BBB");
+	}
+
+	@BenchmarkOptions(benchmarkRounds = 1, warmupRounds = 1)
+	@Test
+	@Ignore
+	public void shouldPermitAll() {
+
+		for (int i = 0; i < 2000000; i++) {
+			final Map<String, String> filteredProperties = unit.filterDeniedParams(propertyMap, CHANNEL);
+			assertThat(filteredProperties.size(), is(4));
+		}
+	}
+
+	@BenchmarkOptions(benchmarkRounds = 1, warmupRounds = 1)
+	@Test
+	@Ignore
+	public void shouldAllowTraceePrefixedParameters() {
+		System.setProperty(PropertiesBasedTraceeFilterConfiguration.TRACEE_DEFAULT_PROFILE_PREFIX + CHANNEL, "tracee.*");
+
+		for (int i = 0; i < 2000000; i++) {
+			final Map<String, String> filteredProperties = unit.filterDeniedParams(propertyMap, CHANNEL);
+			assertThat(filteredProperties.size(), is(2));
+		}
+	}
+}

--- a/core/src/test/java/io/tracee/configuration/PropertiesBasedTraceeFilterConfigurationTest.java
+++ b/core/src/test/java/io/tracee/configuration/PropertiesBasedTraceeFilterConfigurationTest.java
@@ -1,5 +1,7 @@
 package io.tracee.configuration;
 
+import io.tracee.SimpleTraceeBackend;
+import io.tracee.TraceeBackend;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -18,24 +20,24 @@ import static org.mockito.Mockito.when;
 public class PropertiesBasedTraceeFilterConfigurationTest {
 
 	private PropertyChain propertyChain = Mockito.mock(PropertyChain.class);
-	private PropertiesBasedTraceeFilterConfiguration unit = new PropertiesBasedTraceeFilterConfiguration(propertyChain);
-
+	private TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+	private PropertiesBasedTraceeFilterConfiguration unit = new PropertiesBasedTraceeFilterConfiguration(backend.getLoggerFactory(), propertyChain);
 
 	@Test
 	public void testShouldPropagatePositive() {
-		when(propertyChain.getProperty(TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn(".*");
+		when(propertyChain.getProperty(TRACEE_DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn(".*");
 		assertTrue(unit.shouldProcessParam("foo", AsyncDispatch));
 	}
 
 	@Test
 	public void testShouldPropagateNegative() {
-		when(propertyChain.getProperty(TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn("a,b,c");
+		when(propertyChain.getProperty(TRACEE_DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn("a,b,c");
 		assertFalse(unit.shouldProcessParam("foo", AsyncDispatch));
 	}
 
 	@Test
 	public void testShouldAllowRegexInPatterns() {
-		when(propertyChain.getProperty(TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn("b[oa]+b");
+		when(propertyChain.getProperty(TRACEE_DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn("b[oa]+b");
 		assertTrue(unit.shouldProcessParam("baab", AsyncDispatch));
 		assertTrue(unit.shouldProcessParam("boob", AsyncDispatch));
 	}
@@ -47,31 +49,31 @@ public class PropertiesBasedTraceeFilterConfigurationTest {
 
 	@Test
 	public void testShouldProcessIfDisabledByConfiguration() {
-		when(propertyChain.getProperty(TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn(" \t\n");
+		when(propertyChain.getProperty(TRACEE_DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn(" \t\n");
 		assertFalse(unit.shouldProcessContext(AsyncDispatch));
 	}
 
 	@Test
 	public void testShouldProcessIfAnyPatternIsGiven() {
-		when(propertyChain.getProperty(TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn("a");
+		when(propertyChain.getProperty(TRACEE_DEFAULT_PROFILE_PREFIX + AsyncDispatch.name())).thenReturn("a");
 		assertTrue(unit.shouldProcessContext(AsyncDispatch));
 	}
 
 	@Test
 	public void testGeneratedRequestIdLength() {
-		when(propertyChain.getProperty(TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + GENERATE_REQUEST_ID)).thenReturn("1");
+		when(propertyChain.getProperty(TRACEE_DEFAULT_PROFILE_PREFIX + GENERATE_REQUEST_ID)).thenReturn("1");
 		assertThat(unit.generatedRequestIdLength(), equalTo(1));
 	}
 
 	@Test
 	public void testGeneratedRequestIdNonNumericMeansZero() {
-		when(propertyChain.getProperty(TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + GENERATE_REQUEST_ID)).thenReturn("false");
+		when(propertyChain.getProperty(TRACEE_DEFAULT_PROFILE_PREFIX + GENERATE_REQUEST_ID)).thenReturn("false");
 		assertThat(unit.generatedRequestIdLength(), equalTo(0));
 	}
 
 	@Test
 	public void testGeneratedSessionIdLength() {
-		when(propertyChain.getProperty((TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + GENERATE_SESSION_ID))).thenReturn("42");
+		when(propertyChain.getProperty((TRACEE_DEFAULT_PROFILE_PREFIX + GENERATE_SESSION_ID))).thenReturn("42");
 		assertThat(unit.generatedSessionIdLength(), equalTo(42));
 	}
 
@@ -83,10 +85,8 @@ public class PropertiesBasedTraceeFilterConfigurationTest {
 
 	@Test
 	public void testFilterDeniedParamsPassesWhitelisted() {
-		when(propertyChain.getProperty(TRACEE_CONFIG_PREFIX + DEFAULT_PROFILE_PREFIX + IncomingRequest.name())).thenReturn("Foo");
+		when(propertyChain.getProperty(TRACEE_DEFAULT_PROFILE_PREFIX + IncomingRequest.name())).thenReturn("Foo");
 		final Map<String, String> unfiltered = Collections.singletonMap("Foo", "Bar");
 		assertThat(unit.filterDeniedParams(unfiltered,Channel.IncomingRequest), equalTo(unfiltered));
 	}
-
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
 		<mockito.version>1.10.8</mockito.version>
 		<powermock.version>1.6.1</powermock.version>
 		<equalsverifier.version>1.6</equalsverifier.version>
+		<junit-benchmarks.version>0.7.2</junit-benchmarks.version>
 
 		<!-- dependency versions -->
 		<slf4j.version>1.6.6</slf4j.version>
@@ -384,6 +385,13 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>com.carrotsearch</groupId>
+				<artifactId>junit-benchmarks</artifactId>
+				<version>${junit-benchmarks.version}</version>
+				<scope>test</scope>
+			</dependency>
+
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>


### PR DESCRIPTION
Due caching of property filtering configuration we could skip string tokenizing and regex compilation and use a LRU cache instead.

With 2000000 filterings in a simple microbenchmark:
Pattern .* (permit all): old: 2seconds, new: 1,4seconds
Pattern tracee.* (permit keys prefixed with 'tracee'): Old: 5,8secs, new: 2,8secs