### PR TITLE
SpringMVC: Clear tracee backend in afterCompletion phase

### DIFF
--- a/binding/springmvc/src/main/java/io/tracee/binding/springmvc/TraceeInterceptor.java
+++ b/binding/springmvc/src/main/java/io/tracee/binding/springmvc/TraceeInterceptor.java
@@ -70,12 +70,11 @@ public final class TraceeInterceptor implements HandlerInterceptor {
 			final Map<String, String> filteredContext = configuration.filterDeniedParams(backend.copyToMap(), OutgoingResponse);
 			response.setHeader(outgoingHeaderName, httpHeaderSerialization.render(filteredContext));
 		}
-		backend.clear();
 	}
 
 	@Override
 	public void afterCompletion(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object o, Exception e) throws Exception {
-
+		backend.clear();
 	}
 
 	public void setOutgoingHeaderName(String outgoingHeaderName) {

--- a/binding/springmvc/src/test/java/io/tracee/binding/springmvc/TraceeInterceptorTest.java
+++ b/binding/springmvc/src/test/java/io/tracee/binding/springmvc/TraceeInterceptorTest.java
@@ -127,7 +127,7 @@ public class TraceeInterceptorTest {
 
 	@Test
 	public void shouldCleanupAfterProcessing() throws Exception {
-		unit.postHandle(httpServletRequest, httpServletResponse, new Object(), null);
+		unit.afterCompletion(httpServletRequest, httpServletResponse, new Object(), null);
 		verify(mockedBackend).clear();
 	}
 


### PR DESCRIPTION
This PR cleans the backend (later) in the 'afterCompletion'-Phase of the spring mvc interceptor.

I'm not sure but this may fix our issue that some logmessages are without tracee keys. My current explaination: We clean the context to early and the log-message hasn't be created by slf4j/logback - some lazy/async behavior?.