### PR TITLE
First approach to fix issue #106

### DIFF
--- a/binding/cxf/pom.xml
+++ b/binding/cxf/pom.xml
@@ -33,9 +33,16 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-api</artifactId>
+			<version>${cxf.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-bindings-soap</artifactId>
 			<version>${cxf.version}</version>
 			<scope>provided</scope>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/AbstractTraceeInInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/AbstractTraceeInInterceptor.java
@@ -49,10 +49,14 @@ abstract class AbstractTraceeInInterceptor extends AbstractPhaseInterceptor<Mess
 
 			LOGGER.debug("Interceptor handles message!");
 			if (filterConfiguration.shouldProcessContext(channel)) {
-				if (message instanceof SoapMessage) {
-					handleSoapMessage((SoapMessage) message, filterConfiguration);
-				} else {
+				if (Boolean.TRUE == message.getExchange().get(Message.REST_MESSAGE)) {
 					handleHttpMessage(message, filterConfiguration);
+				} else {
+					try {
+						handleSoapMessage((SoapMessage) message, filterConfiguration);
+					} catch (NoClassDefFoundError e) {
+						LOGGER.error("Should handle SOAP-message but it seems that cxf soap dependency is not on the classpath. Unable to parse Tracee-Headers: {}", e.getMessage(), e);
+					}
 				}
 			}
 		}

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingRequestMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingRequestMessageTest.java
@@ -3,19 +3,25 @@ package io.tracee.binding.cxf.interceptor;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class IncomingRequestMessageTest {
 
@@ -29,6 +35,9 @@ public class IncomingRequestMessageTest {
 	public void onSetup() throws Exception {
 		backend.clear();
 		unit = new TraceeRequestInInterceptor(backend);
+
+		when(message.getExchange()).thenReturn(mock(Exchange.class));
+		when(message.getExchange().get(eq(Message.REST_MESSAGE))).thenReturn(Boolean.TRUE);
 	}
 
 	@Test
@@ -40,7 +49,7 @@ public class IncomingRequestMessageTest {
 	public void shouldHandleMessageWithoutTraceeHeader() {
 		final Map<String, List<String>> headers = new HashMap<String, List<String>>();
 		final String context = "myContext";
-		headers.put(TraceeConstants.TPIC_HEADER, Arrays.asList(context));
+		headers.put(TraceeConstants.TPIC_HEADER, Collections.singletonList(context));
 		message.put(Message.PROTOCOL_HEADERS, headers);
 		unit.handleMessage(message);
 		assertThat(backend.copyToMap(), hasKey(TraceeConstants.INVOCATION_ID_KEY));

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingRequestSoapMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingRequestSoapMessageTest.java
@@ -8,6 +8,7 @@ import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.databinding.DataWriter;
 import org.apache.cxf.headers.Header;
 import org.apache.cxf.jaxb.JAXBDataBinding;
+import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,9 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class IncomingRequestSoapMessageTest {
 
@@ -33,12 +37,14 @@ public class IncomingRequestSoapMessageTest {
 
 	private AbstractTraceeInInterceptor inInterceptor;
 
-	private final SoapMessage soapMessage = new SoapMessage(new MessageImpl());
+	private final SoapMessage soapMessage = spy(new SoapMessage(new MessageImpl()));
 
 	@Before
 	public void onSetup() throws Exception {
 		backend.clear();
 		inInterceptor = new TraceeRequestInInterceptor(backend);
+
+		when(soapMessage.getExchange()).thenReturn(mock(Exchange.class));
 	}
 
 	@Test
@@ -55,6 +61,8 @@ public class IncomingRequestSoapMessageTest {
 
 		inInterceptor.handleMessage(soapMessage);
 		assertThat(backend.copyToMap(), not(hasKey("mySoapKey")));
+
+		when(soapMessage.getExchange()).thenReturn(mock(Exchange.class));
 	}
 
 	@Test

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/OutgoingMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/OutgoingMessageTest.java
@@ -6,6 +6,7 @@ import io.tracee.TraceeConstants;
 import io.tracee.transport.HttpHeaderTransport;
 
 import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.Before;
@@ -16,6 +17,10 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class OutgoingMessageTest {
 
@@ -23,7 +28,7 @@ public class OutgoingMessageTest {
 
 	private AbstractTraceeOutInterceptor outInterceptor;
 
-	private final MessageImpl message = new MessageImpl();
+	private final MessageImpl message = spy(new MessageImpl());
 
 	private HttpHeaderTransport httpSerializer;
 
@@ -32,6 +37,9 @@ public class OutgoingMessageTest {
 		backend.clear();
 		outInterceptor = new TraceeResponseOutInterceptor(backend);
 		httpSerializer = new HttpHeaderTransport();
+
+		when(message.getExchange()).thenReturn(mock(Exchange.class));
+		when(message.getExchange().get(eq(Message.REST_MESSAGE))).thenReturn(Boolean.TRUE);
 	}
 
 	@Test

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/OutgoingSoapMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/OutgoingSoapMessageTest.java
@@ -7,8 +7,10 @@ import io.tracee.transport.jaxb.TpicMap;
 import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.headers.Header;
 import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.xml.bind.JAXBException;
@@ -21,13 +23,20 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class OutgoingSoapMessageTest {
 
 	private final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
 	private final Interceptor<Message> outInterceptor = new TraceeResponseOutInterceptor(backend);
-	private final SoapMessage soapMessage = new SoapMessage(new MessageImpl());
+	private final SoapMessage soapMessage = spy(new SoapMessage(new MessageImpl()));
 
+	@Before
+	public void before() {
+		when(soapMessage.getExchange()).thenReturn(mock(Exchange.class));
+	}
 
 	@Test
 	public void shouldHandleSoapMessageWithoutSoapHeader() {
@@ -53,5 +62,4 @@ public class OutgoingSoapMessageTest {
 		outInterceptor.handleMessage(soapMessage);
 		assertThat(backend.copyToMap(), equalTo(Collections.<String,String>emptyMap()));
 	}
-
 }


### PR DESCRIPTION
There is a constant value attached to the exchange if the type of the message is a REST message. Instead of the class, I check for the value in the hashmap.
Found the approach a few weeks ago in a CXF discussion as workaround, so I think it's the best practise how we can solve this.