### PR TITLE
Add Slf4J backend to cache

### DIFF
--- a/core/src/test/java/io/tracee/backend/slf4j/Slf4jTraceeBackendIT.java
+++ b/core/src/test/java/io/tracee/backend/slf4j/Slf4jTraceeBackendIT.java
@@ -1,0 +1,24 @@
+package io.tracee.backend.slf4j;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class Slf4jTraceeBackendIT {
+
+	@Test
+	public void traceeShouldReturnSlf4JBackendByDefault() {
+		assertThat(Tracee.getBackend(), is(instanceOf(TraceeBackend.class)));
+	}
+
+	@Test
+	public void shouldReturnAlwaystheSameDefaultBackend() {
+		final TraceeBackend backend = Tracee.getBackend();
+		assertThat(Tracee.getBackend(), is(sameInstance(backend)));
+	}
+}


### PR DESCRIPTION
If no backend can determined by SPI, the default SLF4J backend is used. But in this case the lookup and initialization (`Class.forName(..)`) takes place by every invocation. This PR adds the Slf4J backend to the cache. The cache-key is the current classloader.