### PR TITLE
Test and implementation refactoring

### DIFF
--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/TraceeCxfFeature.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/TraceeCxfFeature.java
@@ -2,7 +2,11 @@ package io.tracee.binding.cxf;
 
 import io.tracee.Tracee;
 import io.tracee.TraceeBackend;
-import io.tracee.binding.cxf.interceptor.*;
+import io.tracee.binding.cxf.interceptor.TraceeRequestInInterceptor;
+import io.tracee.binding.cxf.interceptor.TraceeRequestOutInterceptor;
+import io.tracee.binding.cxf.interceptor.TraceeResponseInInterceptor;
+import io.tracee.binding.cxf.interceptor.TraceeResponseOutInterceptor;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.apache.cxf.Bus;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -13,15 +17,16 @@ public class TraceeCxfFeature extends AbstractFeature {
 	private TraceeBackend backend;
 
 	public TraceeCxfFeature() {
-		this(Tracee.getBackend());
+		this(Tracee.getBackend(), Profile.DEFAULT);
 	}
 
-	public TraceeCxfFeature(TraceeBackend backend) {
+	TraceeCxfFeature(TraceeBackend backend, String profile) {
 		this.backend = backend;
+		this.profile = profile;
 	}
 
 	public TraceeCxfFeature(String profile) {
-		this.profile = profile;
+		this(Tracee.getBackend(), profile);
 	}
 
 	@Override

--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/AbstractTraceeOutInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/AbstractTraceeOutInterceptor.java
@@ -74,7 +74,7 @@ abstract class AbstractTraceeOutInterceptor extends AbstractPhaseInterceptor<Mes
 					new JAXBDataBinding(TpicMap.class));
 			soapMessage.getHeaders().add(tpicHeader);
 		} catch (JAXBException e) {
-			LOGGER.warn("Error occured during TracEE soap header creation: " + e.getMessage());
+			LOGGER.warn("Error occured during TracEE soap header creation: {}", e.getMessage());
 			LOGGER.debug("Detailed exception", e);
 		}
 	}

--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeRequestInInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeRequestInInterceptor.java
@@ -2,6 +2,8 @@ package io.tracee.binding.cxf.interceptor;
 
 import io.tracee.TraceeBackend;
 import io.tracee.Utilities;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.Phase;
@@ -11,7 +13,7 @@ import static io.tracee.configuration.TraceeFilterConfiguration.Channel.Incoming
 public class TraceeRequestInInterceptor extends AbstractTraceeInInterceptor {
 
 	public TraceeRequestInInterceptor(TraceeBackend backend) {
-		this(backend, null);
+		this(backend, Profile.DEFAULT);
 	}
 
 	public TraceeRequestInInterceptor(TraceeBackend backend, String profile) {

--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeRequestOutInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeRequestOutInterceptor.java
@@ -1,6 +1,8 @@
 package io.tracee.binding.cxf.interceptor;
 
 import io.tracee.TraceeBackend;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.Phase;
@@ -10,7 +12,7 @@ import static io.tracee.configuration.TraceeFilterConfiguration.Channel.Outgoing
 public class TraceeRequestOutInterceptor extends AbstractTraceeOutInterceptor {
 
 	public TraceeRequestOutInterceptor(TraceeBackend backend) {
-		this(backend, null);
+		this(backend, Profile.DEFAULT);
 	}
 
 	public TraceeRequestOutInterceptor(TraceeBackend backend, String profile) {

--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeResponseInInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeResponseInInterceptor.java
@@ -1,6 +1,8 @@
 package io.tracee.binding.cxf.interceptor;
 
 import io.tracee.TraceeBackend;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.Phase;
@@ -10,7 +12,7 @@ import static io.tracee.configuration.TraceeFilterConfiguration.Channel.Incoming
 public class TraceeResponseInInterceptor extends AbstractTraceeInInterceptor {
 
 	public TraceeResponseInInterceptor(TraceeBackend backend) {
-		this(backend, null);
+		this(backend, Profile.DEFAULT);
 	}
 
 	public TraceeResponseInInterceptor(TraceeBackend backend, String profile) {

--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeResponseOutInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/TraceeResponseOutInterceptor.java
@@ -1,6 +1,8 @@
 package io.tracee.binding.cxf.interceptor;
 
 import io.tracee.TraceeBackend;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
@@ -11,7 +13,7 @@ import static io.tracee.configuration.TraceeFilterConfiguration.Channel.Outgoing
 public class TraceeResponseOutInterceptor extends AbstractTraceeOutInterceptor {
 
 	public TraceeResponseOutInterceptor(TraceeBackend backend) {
-		this(backend, null);
+		this(backend, Profile.DEFAULT);
 	}
 
 	public TraceeResponseOutInterceptor(TraceeBackend backend, String profile) {

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/CxfClientToCxfServerIT.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/CxfClientToCxfServerIT.java
@@ -2,6 +2,8 @@ package io.tracee.binding.cxf;
 
 import io.tracee.TraceeConstants;
 import io.tracee.binding.cxf.testSoapService.HelloWorldTestService;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.apache.cxf.bus.CXFBusFactory;
 import org.apache.cxf.feature.LoggingFeature;
 import org.apache.cxf.frontend.ClientProxyFactoryBean;
@@ -23,12 +25,12 @@ public class CxfClientToCxfServerIT extends AbstractConnectionITHelper {
 	public void setup() {
 		JaxWsServerFactoryBean jaxWsServer = createJaxWsServer();
 		jaxWsServer.getFeatures().add(new LoggingFeature());
-		jaxWsServer.getFeatures().add(new TraceeCxfFeature(serverBackend));
+		jaxWsServer.getFeatures().add(new TraceeCxfFeature(serverBackend, Profile.DEFAULT));
 		server = jaxWsServer.create();
 
 		final ClientProxyFactoryBean factoryBean = new ClientProxyFactoryBean();
 		factoryBean.getFeatures().add(new LoggingFeature());
-		factoryBean.getFeatures().add(new TraceeCxfFeature(clientBackend));
+		factoryBean.getFeatures().add(new TraceeCxfFeature(clientBackend, Profile.DEFAULT));
 		factoryBean.setServiceClass(HelloWorldTestService.class);
 		factoryBean.setBus(CXFBusFactory.getDefaultBus());
 		factoryBean.setAddress(endpointAddress);

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/CxfClientToJaxwsServerIT.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/CxfClientToJaxwsServerIT.java
@@ -3,6 +3,8 @@ package io.tracee.binding.cxf;
 import io.tracee.*;
 import io.tracee.binding.cxf.testSoapService.HelloWorldTestService;
 import io.tracee.binding.jaxws.TraceeClientHandler;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.apache.cxf.feature.LoggingFeature;
 import org.apache.cxf.frontend.ClientProxyFactoryBean;
 import org.apache.cxf.jaxws.JaxWsServerFactoryBean;
@@ -28,7 +30,7 @@ public class CxfClientToJaxwsServerIT extends AbstractConnectionITHelper {
 
 		final ClientProxyFactoryBean factoryBean = new ClientProxyFactoryBean();
 		factoryBean.getFeatures().add(new LoggingFeature());
-		factoryBean.getFeatures().add(new TraceeCxfFeature(clientBackend));
+		factoryBean.getFeatures().add(new TraceeCxfFeature(clientBackend, Profile.DEFAULT));
 		factoryBean.setServiceClass(HelloWorldTestService.class);
 		factoryBean.setAddress(endpointAddress);
 		helloWorldPort = (HelloWorldTestService) factoryBean.create();

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/JaxwsClientToCxfServerIT.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/JaxwsClientToCxfServerIT.java
@@ -3,6 +3,8 @@ package io.tracee.binding.cxf;
 import io.tracee.TraceeConstants;
 import io.tracee.binding.cxf.testSoapService.HelloWorldTestService;
 import io.tracee.binding.jaxws.TraceeClientHandler;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.apache.cxf.Bus;
 import org.apache.cxf.bus.CXFBusFactory;
 import org.apache.cxf.feature.LoggingFeature;
@@ -27,7 +29,7 @@ public class JaxwsClientToCxfServerIT extends AbstractConnectionITHelper {
 
 		JaxWsServerFactoryBean jaxWsServer = createJaxWsServer();
 		jaxWsServer.getFeatures().add(new LoggingFeature());
-		jaxWsServer.getFeatures().add(new TraceeCxfFeature(serverBackend));
+		jaxWsServer.getFeatures().add(new TraceeCxfFeature(serverBackend, Profile.DEFAULT));
 		server = jaxWsServer.create();
 
 		JaxWsProxyFactoryBean factoryBean = new JaxWsProxyFactoryBean();

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/TraceeCxfFeatureTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/TraceeCxfFeatureTest.java
@@ -1,5 +1,9 @@
 package io.tracee.binding.cxf;
 
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import org.apache.cxf.Bus;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -11,7 +15,12 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TraceeCxfFeatureTest {
@@ -34,25 +43,43 @@ public class TraceeCxfFeatureTest {
 
 	@Test
 	public void shouldAddInInterceptorToDefaultMessage() {
-		new TraceeCxfFeature(backend).initializeProvider(interceptorProvider, bus);
+		new TraceeCxfFeature(backend, Profile.DEFAULT).initializeProvider(interceptorProvider, bus);
 		verify(interceptorProvider, times(2)).getInInterceptors();
 	}
 
 	@Test
 	public void shouldAddInFaultInterceptorToDefaultMessage() {
-		new TraceeCxfFeature(backend).initializeProvider(interceptorProvider, bus);
+		new TraceeCxfFeature(backend, Profile.DEFAULT).initializeProvider(interceptorProvider, bus);
 		verify(interceptorProvider, times(1)).getInFaultInterceptors();
 	}
 
 	@Test
 	public void shouldAddOutInterceptorToDefaultMessage() {
-		new TraceeCxfFeature(backend).initializeProvider(interceptorProvider, bus);
+		new TraceeCxfFeature(backend, Profile.DEFAULT).initializeProvider(interceptorProvider, bus);
 		verify(interceptorProvider, times(2)).getOutInterceptors();
 	}
 
 	@Test
 	public void shouldAddOutFaultInterceptorToDefaultMessage() {
-		new TraceeCxfFeature(backend).initializeProvider(interceptorProvider, bus);
+		new TraceeCxfFeature(backend, Profile.DEFAULT).initializeProvider(interceptorProvider, bus);
 		verify(interceptorProvider, times(1)).getOutFaultInterceptors();
+	}
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeCxfFeature feature = new TraceeCxfFeature();
+		assertThat((String) FieldAccessUtil.getFieldVal(feature, "profile"), is(Profile.DEFAULT));
+	}
+
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeCxfFeature feature = new TraceeCxfFeature();
+		assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(feature, "backend"), is(Tracee.getBackend()));
+	}
+
+	@Test
+	public void constructorStoresProfileNameInternal() {
+		final TraceeCxfFeature feature = new TraceeCxfFeature("testProf");
+		assertThat((String) FieldAccessUtil.getFieldVal(feature, "profile"), is("testProf"));
 	}
 }

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingRequestMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingRequestMessageTest.java
@@ -1,5 +1,6 @@
 package io.tracee.binding.cxf.interceptor;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
@@ -18,6 +19,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -25,16 +27,15 @@ import static org.mockito.Mockito.when;
 
 public class IncomingRequestMessageTest {
 
-	private AbstractTraceeInInterceptor unit;
-
 	private static final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+
+	private TraceeRequestInInterceptor unit = new TraceeRequestInInterceptor(backend);;
 
 	private final MessageImpl message = spy(new MessageImpl());
 
 	@Before
 	public void onSetup() throws Exception {
 		backend.clear();
-		unit = new TraceeRequestInInterceptor(backend);
 
 		when(message.getExchange()).thenReturn(mock(Exchange.class));
 		when(message.getExchange().get(eq(Message.REST_MESSAGE))).thenReturn(Boolean.TRUE);
@@ -59,5 +60,11 @@ public class IncomingRequestMessageTest {
 	public void generateInvocationIdUponRequest() {
 		unit.handleMessage(message);
 		assertThat(backend.copyToMap(), hasKey(TraceeConstants.INVOCATION_ID_KEY));
+	}
+
+	@Test
+	public void onIncomingRequestMessagesIamNotTheRequestor() {
+		when(message.get(eq(Message.REQUESTOR_ROLE))).thenReturn(Boolean.FALSE);
+		assertThat(unit.shouldHandleMessage(message), is(true));
 	}
 }

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingResponseMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingResponseMessageTest.java
@@ -1,0 +1,34 @@
+package io.tracee.binding.cxf.interceptor;
+
+import io.tracee.TraceeBackend;
+import io.tracee.testhelper.SimpleTraceeBackend;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class IncomingResponseMessageTest {
+
+	private static final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+
+	private TraceeResponseInInterceptor unit = new TraceeResponseInInterceptor(backend);
+
+	private final MessageImpl message = spy(new MessageImpl());
+
+	@Before
+	public void before() {
+		backend.clear();
+	}
+
+	@Test
+	public void onIncomingResponseMessagesIamTheRequestor() {
+		when(message.get(eq(Message.REQUESTOR_ROLE))).thenReturn(Boolean.TRUE);
+		assertThat(unit.shouldHandleMessage(message), is(true));
+	}
+}

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingSoapRequestMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingSoapRequestMessageTest.java
@@ -1,8 +1,8 @@
 package io.tracee.binding.cxf.interceptor;
 
-import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
+import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.transport.jaxb.TpicMap;
 import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.databinding.DataWriter;
@@ -31,11 +31,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-public class IncomingRequestSoapMessageTest {
+public class IncomingSoapRequestMessageTest {
 
 	private static final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
 
-	private AbstractTraceeInInterceptor inInterceptor;
+	private TraceeRequestInInterceptor inInterceptor;
 
 	private final SoapMessage soapMessage = spy(new SoapMessage(new MessageImpl()));
 
@@ -78,13 +78,13 @@ public class IncomingRequestSoapMessageTest {
 	}
 
 	private Element render(Map<String, String> context) throws JAXBException, SOAPException {
-			final MessageFactory messageFactory = MessageFactory.newInstance();
+		final MessageFactory messageFactory = MessageFactory.newInstance();
 		final SOAPHeaderElement dummyContainerElement = messageFactory.createMessage().getSOAPHeader().addHeaderElement(new QName("http://test", "elem"));
 
 
 		DataWriter<Node> writer = new JAXBDataBinding(TpicMap.class).createWriter(Node.class);
-			writer.write(TpicMap.wrap(context), dummyContainerElement);
+		writer.write(TpicMap.wrap(context), dummyContainerElement);
 
-		return (Element)dummyContainerElement.getFirstChild();
+		return (Element) dummyContainerElement.getFirstChild();
 	}
 }

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/OutgoingRequestMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/OutgoingRequestMessageTest.java
@@ -1,0 +1,36 @@
+package io.tracee.binding.cxf.interceptor;
+
+import io.tracee.TraceeBackend;
+import io.tracee.testhelper.SimpleTraceeBackend;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class OutgoingRequestMessageTest {
+
+	private static final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+
+	private TraceeRequestOutInterceptor unit = new TraceeRequestOutInterceptor(backend);
+
+	private final MessageImpl message = spy(new MessageImpl());
+
+	@Before
+	public void before() {
+		backend.clear();
+	}
+
+	@Test
+	public void onOutgoingRequestMessagesIamTheRequestor() {
+		when(message.get(eq(Message.REQUESTOR_ROLE))).thenReturn(Boolean.TRUE);
+		assertThat(unit.shouldHandleMessage(message), is(true));
+	}
+
+
+}

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/OutgoingResponseMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/OutgoingResponseMessageTest.java
@@ -22,11 +22,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-public class OutgoingMessageTest {
+public class OutgoingResponseMessageTest {
 
 	private static final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
 
-	private AbstractTraceeOutInterceptor outInterceptor;
+	private TraceeResponseOutInterceptor outInterceptor;
 
 	private final MessageImpl message = spy(new MessageImpl());
 

--- a/binding/httpclient/src/main/java/io/tracee/binding/httpclient/TraceeHttpClientDecorator.java
+++ b/binding/httpclient/src/main/java/io/tracee/binding/httpclient/TraceeHttpClientDecorator.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import static io.tracee.configuration.TraceeFilterConfiguration.Channel.IncomingResponse;
 import static io.tracee.configuration.TraceeFilterConfiguration.Channel.OutgoingRequest;
+import static io.tracee.configuration.TraceeFilterConfiguration.Profile.*;
 
 /**
  * Wraps an HttpClient and performs TraceEE context propagation on execute methods.
@@ -33,7 +34,7 @@ public class TraceeHttpClientDecorator extends HttpClient {
 	private final String profile;
 
 	public static HttpClient wrap(HttpClient httpClient) {
-		return wrap(httpClient, null);
+		return wrap(httpClient, DEFAULT);
 	}
 
 	public static HttpClient wrap(HttpClient httpClient, String profile) {

--- a/binding/httpcomponents/src/main/java/io/tracee/binding/httpcomponents/TraceeHttpRequestInterceptor.java
+++ b/binding/httpcomponents/src/main/java/io/tracee/binding/httpcomponents/TraceeHttpRequestInterceptor.java
@@ -4,6 +4,7 @@ import io.tracee.Tracee;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
 import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import io.tracee.transport.HttpHeaderTransport;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
@@ -20,7 +21,7 @@ public class TraceeHttpRequestInterceptor implements HttpRequestInterceptor {
 	private final String profile;
 
 	public TraceeHttpRequestInterceptor() {
-		this(null);
+		this(Profile.DEFAULT);
 	}
 
 	public TraceeHttpRequestInterceptor(String profile) {

--- a/binding/httpcomponents/src/main/java/io/tracee/binding/httpcomponents/TraceeHttpResponseInterceptor.java
+++ b/binding/httpcomponents/src/main/java/io/tracee/binding/httpcomponents/TraceeHttpResponseInterceptor.java
@@ -4,6 +4,7 @@ import io.tracee.Tracee;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
 import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import io.tracee.transport.HttpHeaderTransport;
 import org.apache.http.Header;
 import org.apache.http.HttpException;
@@ -25,7 +26,7 @@ public class TraceeHttpResponseInterceptor implements HttpResponseInterceptor {
 	private final String profile;
 
 	public TraceeHttpResponseInterceptor() {
-		this(null);
+		this(Profile.DEFAULT);
 	}
 
 	public TraceeHttpResponseInterceptor(String profile) {

--- a/binding/httpcomponents/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpInterceptorsIT.java
+++ b/binding/httpcomponents/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpInterceptorsIT.java
@@ -25,8 +25,8 @@ import static org.hamcrest.Matchers.equalTo;
 public class TraceeHttpInterceptorsIT {
 
 	private Server server;
-	private String serverEndpoint;
 
+	private String serverEndpoint;
 
 	@Test
 	public void testWritesToServerAndParsesResponse() throws IOException {
@@ -48,7 +48,7 @@ public class TraceeHttpInterceptorsIT {
 		server = new Server(new InetSocketAddress("127.0.0.1", 0));
 		server.setHandler(requestHandler);
 		server.start();
-		serverEndpoint = "http://"+server.getConnectors()[0].getName();
+		serverEndpoint = "http://" + server.getConnectors()[0].getName();
 	}
 
 	private final Handler requestHandler = new AbstractHandler() {
@@ -71,5 +71,4 @@ public class TraceeHttpInterceptorsIT {
 			server.join();
 		}
 	}
-
 }

--- a/binding/httpcomponents/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpRequestInterceptorTest.java
+++ b/binding/httpcomponents/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpRequestInterceptorTest.java
@@ -1,5 +1,9 @@
 package io.tracee.binding.httpcomponents;
 
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeConstants;
 import org.apache.http.HttpRequest;
@@ -9,6 +13,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 public class TraceeHttpRequestInterceptorTest {
@@ -27,4 +32,22 @@ public class TraceeHttpRequestInterceptorTest {
         assertThat("HttpRequest contains TracEE Context Header", httpRequest.containsHeader(TraceeConstants.TPIC_HEADER), equalTo(true));
         assertThat(httpRequest.getFirstHeader(TraceeConstants.TPIC_HEADER).getValue(), equalTo("foo=bar"));
     }
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeHttpRequestInterceptor interceptor = new TraceeHttpRequestInterceptor();
+		assertThat((String) FieldAccessUtil.getFieldVal(interceptor, "profile"), is(TraceeFilterConfiguration.Profile.DEFAULT));
+	}
+
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeHttpRequestInterceptor interceptor = new TraceeHttpRequestInterceptor();
+		assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(interceptor, "backend"), is(Tracee.getBackend()));
+	}
+
+	@Test
+	public void constructorStoresProfileNameInternal() {
+		final TraceeHttpRequestInterceptor interceptor = new TraceeHttpRequestInterceptor("testProf");
+		assertThat((String) FieldAccessUtil.getFieldVal(interceptor, "profile"), is("testProf"));
+	}
 }

--- a/binding/httpcomponents/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpResponseInterceptorTest.java
+++ b/binding/httpcomponents/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpResponseInterceptorTest.java
@@ -1,5 +1,9 @@
 package io.tracee.binding.httpcomponents;
 
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeConstants;
 import org.apache.http.HttpResponse;
@@ -11,6 +15,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 public class TraceeHttpResponseInterceptorTest {
@@ -26,5 +31,21 @@ public class TraceeHttpResponseInterceptorTest {
         assertThat(backend.get("foobi"), equalTo("bar"));
     }
 
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeHttpResponseInterceptor injector = new TraceeHttpResponseInterceptor();
+		assertThat((String) FieldAccessUtil.getFieldVal(injector, "profile"), is(TraceeFilterConfiguration.Profile.DEFAULT));
+	}
 
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeHttpResponseInterceptor injector = new TraceeHttpResponseInterceptor();
+		assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(injector, "backend"), is(Tracee.getBackend()));
+	}
+
+	@Test
+	public void constructorStoresProfileNameInternal() {
+		final TraceeHttpResponseInterceptor injector = new TraceeHttpResponseInterceptor("testProf");
+		assertThat((String) FieldAccessUtil.getFieldVal(injector, "profile"), is("testProf"));
+	}
 }

--- a/binding/jaxrs2/src/test/java/io/tracee/binding/jaxrs2/TraceeClientFilterRequestTest.java
+++ b/binding/jaxrs2/src/test/java/io/tracee/binding/jaxrs2/TraceeClientFilterRequestTest.java
@@ -1,8 +1,12 @@
 package io.tracee.binding.jaxrs2;
 
+import io.tracee.Tracee;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -37,7 +41,7 @@ public class TraceeClientFilterRequestTest {
         traceeBackend.put("foo", "bar");
         unit.filter(clientRequestContext);
         assertThat((String) clientRequestContext.getHeaders().getFirst(TraceeConstants.TPIC_HEADER),
-                containsString("foo=bar"));
+				containsString("foo=bar"));
     }
 
     @Test
@@ -56,4 +60,10 @@ public class TraceeClientFilterRequestTest {
         assertThat((String) clientRequestContext.getHeaders().getFirst(TraceeConstants.TPIC_HEADER),
                 containsString(TraceeConstants.INVOCATION_ID_KEY + "=foo"));
     }
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeClientFilter clientFilter = new TraceeClientFilter();
+		MatcherAssert.assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(clientFilter, "backend"), is(Tracee.getBackend()));
+	}
 }

--- a/binding/jaxrs2/src/test/java/io/tracee/binding/jaxrs2/TraceeContainerFilterRequestTest.java
+++ b/binding/jaxrs2/src/test/java/io/tracee/binding/jaxrs2/TraceeContainerFilterRequestTest.java
@@ -1,8 +1,12 @@
 package io.tracee.binding.jaxrs2;
 
+import io.tracee.Tracee;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -13,6 +17,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
@@ -50,4 +55,10 @@ public class TraceeContainerFilterRequestTest {
         unit.filter(requestContext);
         assertThat(backend.get(TraceeConstants.INVOCATION_ID_KEY), not(isEmptyOrNullString()));
     }
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeContainerFilter containerFilter = new TraceeContainerFilter();
+		MatcherAssert.assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(containerFilter, "backend"), is(Tracee.getBackend()));
+	}
 }

--- a/binding/jaxws/src/main/java/io/tracee/binding/jaxws/AbstractTraceeHandler.java
+++ b/binding/jaxws/src/main/java/io/tracee/binding/jaxws/AbstractTraceeHandler.java
@@ -41,9 +41,7 @@ abstract class AbstractTraceeHandler implements SOAPHandler<SOAPMessageContext> 
     }
 
     @Override
-    public void close(MessageContext context) {
-
-    }
+    public void close(MessageContext context) {}
 
     protected abstract void handleIncoming(SOAPMessageContext context);
 

--- a/binding/jaxws/src/main/java/io/tracee/binding/jaxws/TraceeClientHandler.java
+++ b/binding/jaxws/src/main/java/io/tracee/binding/jaxws/TraceeClientHandler.java
@@ -48,9 +48,7 @@ public class TraceeClientHandler extends AbstractTraceeHandler {
 				}
 			} catch (final SOAPException e) {
 				logger.warn("Error during precessing of inbound soap header: " + e.getMessage());
-				if (logger.isDebugEnabled()) {
-					logger.debug("Error during precessing of inbound soap header: " + e.getMessage(), e);
-				}
+				logger.debug("Detailed: Error during precessing of inbound soap header: {}", e.getMessage(), e);
 			}
 		}
 	}

--- a/binding/jaxws/src/main/java/io/tracee/binding/jaxws/TraceeServerHandler.java
+++ b/binding/jaxws/src/main/java/io/tracee/binding/jaxws/TraceeServerHandler.java
@@ -43,10 +43,8 @@ public class TraceeServerHandler extends AbstractTraceeHandler {
 				traceeBackend.putAll(filteredContext);
 			}
 		} catch (final SOAPException e) {
-			logger.warn("Error during precessing of inbound soap header: " + e.getMessage());
-			if (logger.isDebugEnabled()) {
-				logger.debug("Error during precessing of inbound soap header: " + e.getMessage(), e);
-			}
+			logger.warn("Error during precessing of inbound soap header: {}", e.getMessage());
+			logger.debug("Detailed: Error during precessing of inbound soap header: {}", e.getMessage(), e);
 		}
 
 		Utilities.generateInvocationIdIfNecessary(traceeBackend);
@@ -69,9 +67,7 @@ public class TraceeServerHandler extends AbstractTraceeHandler {
 
 		} catch (final SOAPException e) {
 			logger.error("TraceeServerHandler : Exception occurred during processing of outbound message.");
-			if (logger.isDebugEnabled()) {
-				logger.debug("TraceeServerHandler : Exception occurred during processing of outbound message.", e);
-			}
+			logger.debug("Detailed: TraceeServerHandler : Exception occurred during processing of outbound message: {}", e.getMessage(), e);
 		} finally {
 			// must reset tracee context
 			traceeBackend.clear();

--- a/binding/jaxws/src/test/java/io/tracee/binding/jaxws/AbstractTraceeHandlerTest.java
+++ b/binding/jaxws/src/test/java/io/tracee/binding/jaxws/AbstractTraceeHandlerTest.java
@@ -15,14 +15,9 @@ import static org.mockito.Mockito.*;
 
 public class AbstractTraceeHandlerTest {
 
-	private TestTraceeHandler unit;
-
 	private final TraceeBackend traceeBackend = mock(TraceeBackend.class);
 
-	@Before
-	public void setupMocks() {
-		unit = spy(new TestTraceeHandler(traceeBackend));
-	}
+	private TestTraceeHandler unit = spy(new TestTraceeHandler(traceeBackend));
 
 	@Test
 	public void shouldHandleOutgoingContextInOutgoingMethod() {
@@ -47,6 +42,13 @@ public class AbstractTraceeHandlerTest {
 		unit.handleMessage(messageContext);
 
 		verify(unit).handleIncoming(messageContext);
+	}
+
+	@Test
+	public void closeDoesNothing() {
+		final MessageContext context = mock(MessageContext.class);
+		unit.close(context);
+		verifyZeroInteractions(context, traceeBackend);
 	}
 
 	@Test

--- a/binding/jaxws/src/test/java/io/tracee/binding/jaxws/TraceeClientHandlerTest.java
+++ b/binding/jaxws/src/test/java/io/tracee/binding/jaxws/TraceeClientHandlerTest.java
@@ -66,7 +66,7 @@ public class TraceeClientHandlerTest {
 
 	@Test
 	public void catchExceptionOnReadTpicHeader() throws SOAPException {
-		when(message.getSOAPHeader()).thenThrow(SOAPException.class);
+		when(message.getSOAPHeader()).thenThrow(new SOAPException());
 		unit.handleIncoming(messageContext);
 		assertThat(backend.isEmpty(), is(true));
 	}

--- a/binding/jms/pom.xml
+++ b/binding/jms/pom.xml
@@ -41,17 +41,9 @@
             <version>4.5.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.tracee.backend</groupId>
-            <artifactId>tracee-threadlocal-store</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
 		<dependency>
 			<groupId>io.tracee</groupId>
 			<artifactId>tracee-testhelper</artifactId>
 		</dependency>
     </dependencies>
-
-
 </project>

--- a/binding/jms/src/main/java/io/tracee/binding/jms/TraceeMessageWriter.java
+++ b/binding/jms/src/main/java/io/tracee/binding/jms/TraceeMessageWriter.java
@@ -20,5 +20,4 @@ public final class TraceeMessageWriter {
     public static TopicPublisher wrap(TopicPublisher topicPublisher) {
         return new TraceeTopicPublisher(new TraceeMessageProducer(topicPublisher), topicPublisher);
     }
-
 }

--- a/binding/jms/src/test/java/io/tracee/binding/jms/MessageDelegationTest.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/MessageDelegationTest.java
@@ -9,7 +9,7 @@ import javax.jms.TopicPublisher;
 
 import static org.mockito.Mockito.mock;
 
-public class TestMessageDelegation {
+public class MessageDelegationTest {
 
 	@Test
 	public void delegateTraceeMessageProducerToMessageProducer() {

--- a/binding/jms/src/test/java/io/tracee/binding/jms/TestMDB.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TestMDB.java
@@ -13,16 +13,16 @@ public class TestMDB implements MessageListener {
     @Resource
     private ConnectionFactory connectionFactory;
 
-
     @Resource(name = "Response")
     private Queue responses;
 
     @Override
     public void onMessage(Message message) {
-        Connection connection = null;
-        Session session = null;
-        try {
-            final TextMessage incomingMessage = (TextMessage) message;
+		final TextMessage incomingMessage = (TextMessage) message;
+
+		Connection connection = null;
+		Session session = null;
+		try {
             connection = connectionFactory.createConnection();
             connection.start();
             session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);

--- a/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageListenerTest.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageListenerTest.java
@@ -1,7 +1,12 @@
 package io.tracee.binding.jms;
 
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeConstants;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -59,5 +64,11 @@ public class TraceeMessageListenerTest {
 		public void onMessage(Message message) {
 			assertThat(backend.get("contextFromMessage"), is("yes"));
 		}
+	}
+
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeMessageListener listener = new TraceeMessageListener();
+		MatcherAssert.assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(listener, "backend"), is(Tracee.getBackend()));
 	}
 }

--- a/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageProducerTest.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageProducerTest.java
@@ -25,7 +25,6 @@ public class TraceeMessageProducerTest {
 	private final TraceeMessageProducer unit = new TraceeMessageProducer(messageProducer, backend);
 	private final Message message = mock(Message.class);
 
-
 	@Test
 	public void testWriteTraceeContextToMessage() throws Exception {
 		backend.put("random", "entry");

--- a/binding/quartz/src/test/java/io/tracee/binding/quartz/TraceeContextInjectorTest.java
+++ b/binding/quartz/src/test/java/io/tracee/binding/quartz/TraceeContextInjectorTest.java
@@ -1,5 +1,7 @@
 package io.tracee.binding.quartz;
 
+import io.tracee.Tracee;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.configuration.TraceeFilterConfiguration.Profile;
@@ -57,5 +59,23 @@ public class TraceeContextInjectorTest {
 		unit.injectContext(jobDetail);
 		assertThat(jobDetail.getJobDataMap(), hasKey(TPIC_HEADER));
 		assertThat((Map<String, String>) jobDetail.getJobDataMap().get(TPIC_HEADER), hasEntry("testKey", "testValue"));
+	}
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeContextInjector injector = new TraceeContextInjector();
+		assertThat((String) FieldAccessUtil.getFieldVal(injector, "profile"), is(Profile.DEFAULT));
+	}
+
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeContextInjector injector = new TraceeContextInjector();
+		assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(injector, "backend"), is(Tracee.getBackend()));
+	}
+
+	@Test
+	public void constructorStoresProfileNameInternal() {
+		final TraceeContextInjector injector = new TraceeContextInjector("testProf");
+		assertThat((String) FieldAccessUtil.getFieldVal(injector, "profile"), is("testProf"));
 	}
 }

--- a/binding/springhttpclient/src/main/java/io/tracee/binding/springhttpclient/TraceeClientHttpRequestInterceptor.java
+++ b/binding/springhttpclient/src/main/java/io/tracee/binding/springhttpclient/TraceeClientHttpRequestInterceptor.java
@@ -4,6 +4,7 @@ import io.tracee.Tracee;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
 import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import io.tracee.transport.HttpHeaderTransport;
 
 import org.springframework.http.HttpRequest;
@@ -25,7 +26,7 @@ public final class TraceeClientHttpRequestInterceptor implements ClientHttpReque
 	private final String profile;
 
 	public TraceeClientHttpRequestInterceptor() {
-		this(Tracee.getBackend(), new HttpHeaderTransport(), null);
+		this(Tracee.getBackend(), new HttpHeaderTransport(), Profile.DEFAULT);
 	}
 
 	public TraceeClientHttpRequestInterceptor(String profile) {

--- a/binding/springhttpclient/src/test/java/io/tracee/binding/springhttpclient/TraceeClientHttpRequestInterceptorTest.java
+++ b/binding/springhttpclient/src/test/java/io/tracee/binding/springhttpclient/TraceeClientHttpRequestInterceptorTest.java
@@ -1,6 +1,8 @@
 package io.tracee.binding.springhttpclient;
 
 import io.tracee.*;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.PermitAllTraceeFilterConfiguration;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.transport.HttpHeaderTransport;
@@ -50,7 +52,6 @@ public class TraceeClientHttpRequestInterceptorTest {
 				return new SimpleClientHttpResponse(HttpStatus.NO_CONTENT, "yawn", headers);
 			}
 		});
-
 	}
 
 	@Test
@@ -77,6 +78,22 @@ public class TraceeClientHttpRequestInterceptorTest {
 		};
 	}
 
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeClientHttpRequestInterceptor interceptor = new TraceeClientHttpRequestInterceptor();
+		MatcherAssert.assertThat((String) FieldAccessUtil.getFieldVal(interceptor, "profile"), is(TraceeFilterConfiguration.Profile.DEFAULT));
+	}
 
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeClientHttpRequestInterceptor interceptor = new TraceeClientHttpRequestInterceptor();
+		MatcherAssert.assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(interceptor, "backend"), is(Tracee.getBackend()));
+	}
+
+	@Test
+	public void constructorStoresProfileNameInternal() {
+		final TraceeClientHttpRequestInterceptor interceptor = new TraceeClientHttpRequestInterceptor("testProf");
+		MatcherAssert.assertThat((String) FieldAccessUtil.getFieldVal(interceptor, "profile"), is("testProf"));
+	}
 
 }

--- a/binding/springmvc/src/test/java/io/tracee/binding/springmvc/TraceeInterceptorTest.java
+++ b/binding/springmvc/src/test/java/io/tracee/binding/springmvc/TraceeInterceptorTest.java
@@ -2,8 +2,11 @@ package io.tracee.binding.springmvc;
 
 import io.tracee.*;
 import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import io.tracee.testhelper.EmptyEnumeration;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.PermitAllTraceeFilterConfiguration;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.web.servlet.ModelAndView;
@@ -17,6 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Vector;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -99,6 +104,7 @@ public class TraceeInterceptorTest {
 		unit.setProfileName("FOO");
 		unit.postHandle(httpServletRequest, httpServletResponse, new Object(), new ModelAndView());
 		verify(mockedBackend).getConfiguration("FOO");
+		assertThat(unit.getProfileName(), is("FOO"));
 	}
 
 	@Test
@@ -130,6 +136,12 @@ public class TraceeInterceptorTest {
 	public void shouldCleanupAfterProcessing() throws Exception {
 		unit.afterCompletion(httpServletRequest, httpServletResponse, new Object(), null);
 		verify(mockedBackend).clear();
+	}
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeInterceptor interceptor = new TraceeInterceptor();
+		MatcherAssert.assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(interceptor, "backend"), is(Tracee.getBackend()));
 	}
 
 	private TraceeBackend mockedBackend(TraceeFilterConfiguration filterConfiguration) {

--- a/binding/springrabbitmq/src/main/java/io/tracee/binding/springrabbitmq/TraceeMessagePropertiesConverter.java
+++ b/binding/springrabbitmq/src/main/java/io/tracee/binding/springrabbitmq/TraceeMessagePropertiesConverter.java
@@ -6,6 +6,7 @@ import io.tracee.Tracee;
 import io.tracee.TraceeBackend;
 import io.tracee.Utilities;
 import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
 
@@ -22,7 +23,7 @@ public class TraceeMessagePropertiesConverter extends DefaultMessagePropertiesCo
 	private final String profile;
 
 	public TraceeMessagePropertiesConverter() {
-		this(Tracee.getBackend(), null);
+		this(Tracee.getBackend(), Profile.DEFAULT);
 	}
 
 	public TraceeMessagePropertiesConverter(String profile) {

--- a/binding/springrabbitmq/src/test/java/io/tracee/binding/springrabbitmq/TraceeMessagePropertiesConverterTest.java
+++ b/binding/springrabbitmq/src/test/java/io/tracee/binding/springrabbitmq/TraceeMessagePropertiesConverterTest.java
@@ -3,9 +3,13 @@ package io.tracee.binding.springrabbitmq;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.LongString;
+import io.tracee.Tracee;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.springframework.amqp.core.MessageProperties;
 
@@ -79,6 +83,24 @@ public class TraceeMessagePropertiesConverterTest {
 		assertThat(backend.copyToMap(), hasEntry("inClientBeforeRequest", "true"));
 		assertThat(backend.copyToMap(), hasKey(INVOCATION_ID_KEY));
 		assertThat(backend.size(), is(2));
+	}
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeMessagePropertiesConverter converter = new TraceeMessagePropertiesConverter();
+		MatcherAssert.assertThat((String) FieldAccessUtil.getFieldVal(converter, "profile"), is(TraceeFilterConfiguration.Profile.DEFAULT));
+	}
+
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeMessagePropertiesConverter converter = new TraceeMessagePropertiesConverter();
+		MatcherAssert.assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(converter, "backend"), is(Tracee.getBackend()));
+	}
+
+	@Test
+	public void constructorStoresProfileNameInternal() {
+		final TraceeMessagePropertiesConverter converter = new TraceeMessagePropertiesConverter("testProf");
+		MatcherAssert.assertThat((String) FieldAccessUtil.getFieldVal(converter, "profile"), is("testProf"));
 	}
 
 	private AMQP.BasicProperties createRabbitHeaderWith(final String key, final Object value) {

--- a/binding/springws/src/main/java/io/tracee/binding/springws/AbstractTraceeInterceptor.java
+++ b/binding/springws/src/main/java/io/tracee/binding/springws/AbstractTraceeInterceptor.java
@@ -24,7 +24,7 @@ abstract class AbstractTraceeInterceptor {
 
 	protected final TraceeBackend backend;
 	protected static final Logger logger = LoggerFactory.getLogger(AbstractTraceeInterceptor.class);
-	protected String profile;
+	protected final String profile;
 
 	public AbstractTraceeInterceptor(final TraceeBackend backend, final String profile) {
 		this.backend = backend;

--- a/binding/springws/src/main/java/io/tracee/binding/springws/TraceeClientInterceptor.java
+++ b/binding/springws/src/main/java/io/tracee/binding/springws/TraceeClientInterceptor.java
@@ -2,6 +2,8 @@ package io.tracee.binding.springws;
 
 import io.tracee.Tracee;
 import io.tracee.TraceeBackend;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.springframework.ws.client.WebServiceClientException;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.context.MessageContext;
@@ -14,7 +16,7 @@ import static io.tracee.configuration.TraceeFilterConfiguration.Channel.Outgoing
 public final class TraceeClientInterceptor extends AbstractTraceeInterceptor implements ClientInterceptor{
 
 	public TraceeClientInterceptor() {
-		this(Tracee.getBackend(), null);
+		this(Tracee.getBackend(), Profile.DEFAULT);
 	}
 
 	public TraceeClientInterceptor(final String profile) {

--- a/binding/springws/src/main/java/io/tracee/binding/springws/TraceeEndpointInterceptor.java
+++ b/binding/springws/src/main/java/io/tracee/binding/springws/TraceeEndpointInterceptor.java
@@ -3,6 +3,8 @@ package io.tracee.binding.springws;
 import io.tracee.Tracee;
 import io.tracee.TraceeBackend;
 import io.tracee.Utilities;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
 import org.springframework.ws.context.MessageContext;
 import org.springframework.ws.server.EndpointInterceptor;
 
@@ -12,7 +14,7 @@ import static io.tracee.configuration.TraceeFilterConfiguration.Channel.Outgoing
 public final class TraceeEndpointInterceptor extends AbstractTraceeInterceptor implements EndpointInterceptor {
 
 	public TraceeEndpointInterceptor() {
-		this(Tracee.getBackend(), null);
+		this(Tracee.getBackend(), Profile.DEFAULT);
 	}
 
 	public TraceeEndpointInterceptor(final String profile) {

--- a/binding/springws/src/test/java/io/tracee/binding/springws/TraceeClientInterceptorTest.java
+++ b/binding/springws/src/test/java/io/tracee/binding/springws/TraceeClientInterceptorTest.java
@@ -1,8 +1,13 @@
 package io.tracee.binding.springws;
 
+import io.tracee.Tracee;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
+import io.tracee.testhelper.FieldAccessUtil;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.transport.SoapHeaderTransport;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.ws.WebServiceMessage;
@@ -141,5 +146,23 @@ public class TraceeClientInterceptorTest {
 		when(messageContext.getResponse()).thenReturn(mock(WebServiceMessage.class));
 		unit.handleResponse(messageContext);
 		assertThat(backend.isEmpty(), is(true));
+	}
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeClientInterceptor interceptor = new TraceeClientInterceptor();
+		MatcherAssert.assertThat((String) FieldAccessUtil.getFieldVal(interceptor, "profile"), is(Profile.DEFAULT));
+	}
+
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeClientInterceptor interceptor = new TraceeClientInterceptor();
+		MatcherAssert.assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(interceptor, "backend"), is(Tracee.getBackend()));
+	}
+
+	@Test
+	public void constructorStoresProfileNameInternal() {
+		final TraceeClientInterceptor interceptor = new TraceeClientInterceptor("testProf");
+		MatcherAssert.assertThat((String) FieldAccessUtil.getFieldVal(interceptor, "profile"), is("testProf"));
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -126,10 +126,16 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
 				<configuration>
+					<instrumentation>
+						<ignoreTrivial>true</ignoreTrivial>
+					</instrumentation>
 					<formats>
 						<format>xml</format>
 						<format>html</format>
 					</formats>
+					<maxmem>256m</maxmem>
+					<!-- aggregated reports for multi-module projects -->
+					<aggregate>true</aggregate>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/testhelper/src/main/java/io/tracee/testhelper/FieldAccessUtil.java
+++ b/testhelper/src/main/java/io/tracee/testhelper/FieldAccessUtil.java
@@ -1,0 +1,34 @@
+package io.tracee.testhelper;
+
+import java.lang.reflect.Field;
+
+public final class FieldAccessUtil {
+
+	private FieldAccessUtil() {
+	}
+
+	public static <T> T getFieldVal(final Object obj, String fieldName) {
+		final Class<?> objClass = obj.getClass();
+		return getFieldVal(obj, objClass, fieldName);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T getFieldVal(Object obj, Class<?> objClass, String fieldName) {
+		Field field = null;
+		try {
+			field = objClass.getDeclaredField(fieldName);
+			field.setAccessible(true);
+			return (T) (field.get(obj));
+		} catch (NoSuchFieldException e) {
+			if (objClass.getSuperclass() != null)
+				return (T) getFieldVal(obj, objClass.getSuperclass(), fieldName);
+			throw new RuntimeException(e);
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException(e);
+		} finally {
+			if (field != null) {
+				field.setAccessible(false);
+			}
+		}
+	}
+}

--- a/testhelper/src/test/java/io/tracee/testhelper/FieldAccessUtilTest.java
+++ b/testhelper/src/test/java/io/tracee/testhelper/FieldAccessUtilTest.java
@@ -1,0 +1,20 @@
+package io.tracee.testhelper;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class FieldAccessUtilTest {
+
+	@Test
+	public void shouldAccessFields() {
+		final SimpleTraceeBackend backend = new SimpleTraceeBackend(new PermitAllTraceeFilterConfiguration());
+		backend.put("test", "testVal");
+		@SuppressWarnings("unchecked")
+		final Map<String, String> value = FieldAccessUtil.getFieldVal(backend, "backendValues");
+		assertThat(value.get("test"), is("testVal"));
+	}
+}


### PR DESCRIPTION
Some changes in the implementation:
* Reduce constructor visibility of some bindings if the constuctor is used in test cases only
* Replace the default profile `null` with `Profile.DEFAULT`