### PR TITLE
Do nothing if context is null

### DIFF
--- a/core/src/main/java/io/tracee/transport/SoapHeaderTransport.java
+++ b/core/src/main/java/io/tracee/transport/SoapHeaderTransport.java
@@ -74,10 +74,8 @@ public class SoapHeaderTransport {
 				}
 			}
 		} catch (JAXBException e) {
-			logger.warn("Unable to parse TPIC header: " + e.getMessage());
-			if (logger.isDebugEnabled()) {
-				logger.debug("WithStack: Unable to parse TPIC header: " + e.getMessage(), e);
-			}
+			logger.warn("Unable to parse TPIC header: {}", e.getMessage());
+			logger.debug("WithStack: Unable to parse TPIC header: {}", e.getMessage(), e);
 		}
 		return new HashMap<String, String>();
 	}
@@ -118,14 +116,14 @@ public class SoapHeaderTransport {
 	 * Renders a given context map into a given result that should be the TPIC header node.
 	 */
 	private <T> void renderSoapHeader(final Marshallable<T> marshallable, final Map<String, String> context, T xmlContext) {
+		if (context == null)
+			return;
 		try {
 			final Marshaller marshaller = jaxbContext.createMarshaller();
 			marshallable.marshal(marshaller, TpicMap.wrap(context), xmlContext);
 		} catch (JAXBException e) {
-			logger.warn("Unable to render TPIC header: " + e.getMessage());
-			if (logger.isDebugEnabled()) {
-				logger.debug("WithStack: Unable to render TPIC header: " + e.getMessage(), e);
-			}
+			logger.warn("Unable to render TPIC header: {}", e.getMessage());
+			logger.debug("WithStack: Unable to render TPIC header: {}", e.getMessage(), e);
 		}
 	}
 

--- a/core/src/test/java/io/tracee/transport/SoapHeaderTransportTest.java
+++ b/core/src/test/java/io/tracee/transport/SoapHeaderTransportTest.java
@@ -93,6 +93,24 @@ public class SoapHeaderTransportTest {
 	}
 
 	@Test
+	public void skipRenderingIfContextIsNull() throws SOAPException {
+		final Map<String, String> context = null;
+		final SOAPHeader soapHeader = soapMessage.getSOAPHeader();
+
+		unit.renderSoapHeader(context, soapHeader);
+		assertThat(soapHeader.getChildElements(TraceeConstants.SOAP_HEADER_QNAME).hasNext(), is(false));
+	}
+
+	@Test
+	public void parseTpicHeaderToEmptyMapIfNoTraceeHeaderIsPresent() throws SOAPException {
+		final Map<String, String> context = Collections.emptyMap();
+		final SOAPHeader soapHeader = soapMessage.getSOAPHeader();
+
+		unit.renderSoapHeader(context, soapHeader);
+		assertThat(unit.parseTpicHeader(soapHeader), equalTo(Collections.<String, String>emptyMap()));
+	}
+
+	@Test
 	public void readRealXmlMessageAndParseHeader() throws ParserConfigurationException, IOException, SAXException {
 		final InputStream xmlDoc = ClassLoader.getSystemResourceAsStream("io/tracee/transport/jaxws-output.xml");
 


### PR DESCRIPTION
I think in normal case the context couldn't be `null` but we should skip rendering if `null` instead of a context map is provided.
(I've added some testcases and did some refactoring around the error case logging)