### PR TITLE
Use equals instead of the equal sign. Fixes coverity.

### DIFF
--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/AbstractTraceeInInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/AbstractTraceeInInterceptor.java
@@ -49,7 +49,7 @@ abstract class AbstractTraceeInInterceptor extends AbstractPhaseInterceptor<Mess
 
 			LOGGER.debug("Interceptor handles message!");
 			if (filterConfiguration.shouldProcessContext(channel)) {
-				if (Boolean.TRUE == message.getExchange().get(Message.REST_MESSAGE)) {
+				if (Boolean.TRUE.equals(message.getExchange().get(Message.REST_MESSAGE))) {
 					handleHttpMessage(message, filterConfiguration);
 				} else {
 					try {

--- a/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/AbstractTraceeOutInterceptor.java
+++ b/binding/cxf/src/main/java/io/tracee/binding/cxf/interceptor/AbstractTraceeOutInterceptor.java
@@ -47,7 +47,7 @@ abstract class AbstractTraceeOutInterceptor extends AbstractPhaseInterceptor<Mes
                 final Map<String, String> filteredParams = filterConfiguration.filterDeniedParams(backend.copyToMap(), channel);
 
 				LOGGER.debug("Interceptor handles message!");
-				if (Boolean.TRUE == message.getExchange().get(Message.REST_MESSAGE)) {
+				if (Boolean.TRUE.equals(message.getExchange().get(Message.REST_MESSAGE))) {
 					Map<String, List<String>> responseHeaders = CastUtils.cast((Map<?, ?>) message.get(Message.PROTOCOL_HEADERS));
 					if (responseHeaders == null) {
 						responseHeaders = new HashMap<String, List<String>>();


### PR DESCRIPTION
This could also be a problem if a developer create manual boolean instances (`new Boolean(true)`). In this case the previous comparison won't work!

