### PR TITLE
treat javac warnings as errors

### DIFF
--- a/api/src/test/java/io/tracee/TraceeTest.java
+++ b/api/src/test/java/io/tracee/TraceeTest.java
@@ -39,7 +39,7 @@ public class TraceeTest {
 	public void backendRetrievalShouldWrapRuntimeExceptionIfItOccurs() {
 		try {
 			final BackendProviderResolver testBackendProvider = Mockito.mock(BackendProviderResolver.class);
-			when(testBackendProvider.getBackendProviders()).thenThrow(RuntimeException.class);
+			when(testBackendProvider.getBackendProviders()).thenThrow(new RuntimeException());
 			Tracee.getBackend(testBackendProvider);
 			fail();
 		} catch (RuntimeException e) {

--- a/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingRequestMessageTest.java
+++ b/binding/cxf/src/test/java/io/tracee/binding/cxf/interceptor/IncomingRequestMessageTest.java
@@ -1,17 +1,14 @@
 package io.tracee.binding.cxf.interceptor;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
 import org.apache.cxf.message.Exchange;
-import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -29,7 +26,7 @@ public class IncomingRequestMessageTest {
 
 	private static final TraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
 
-	private TraceeRequestInInterceptor unit = new TraceeRequestInInterceptor(backend);;
+	private TraceeRequestInInterceptor unit = new TraceeRequestInInterceptor(backend);
 
 	private final MessageImpl message = spy(new MessageImpl());
 

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,9 @@
 					<configuration>
 						<source>1.6</source>
 						<target>1.6</target>
+						<compilerArguments>
+							<Werror />
+						</compilerArguments>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
adds javac compiler arguments to maven-compiler-plugin to treat java warnings as errors