### PR TITLE
Resolve #131: Logback dependency in test-scope

### DIFF
--- a/binding/cxf/pom.xml
+++ b/binding/cxf/pom.xml
@@ -63,7 +63,6 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,7 +46,6 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<scope>test</scope>
 		</dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -420,6 +420,7 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
+				<scope>test</scope>
             </dependency>
 
             <!-- Provided dependencies -->


### PR DESCRIPTION
Put logback to the scope 'test' because it's only needed for some tests