### PR TITLE
Testrefactoring of BackendBaseTest

### DIFF
--- a/core/src/test/java/io/tracee/BackendBaseTest.java
+++ b/core/src/test/java/io/tracee/BackendBaseTest.java
@@ -2,162 +2,30 @@ package io.tracee;
 
 import io.tracee.configuration.TraceeFilterConfiguration;
 import io.tracee.configuration.TraceeFilterConfiguration.Channel;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 import static io.tracee.configuration.TraceeFilterConfiguration.Profile.DISABLED;
 import static io.tracee.configuration.TraceeFilterConfiguration.Profile.DISABLE_INBOUND;
 import static io.tracee.configuration.TraceeFilterConfiguration.Profile.DISABLE_OUTBOUND;
 import static io.tracee.configuration.TraceeFilterConfiguration.Profile.HIDE_INBOUND;
 import static io.tracee.configuration.TraceeFilterConfiguration.Profile.HIDE_OUTBOUND;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 public class BackendBaseTest {
 
-	@SuppressWarnings("unchecked")
-	private final ThreadLocal<Set<String>> traceeKeysMock = (ThreadLocal<Set<String>>) mock(ThreadLocal.class);
-
-	private final HashSet<String> traceeKeysSet = Mockito.spy(new HashSet<String>());
-
-
-	private final TestBackend unit = new TestBackend(traceeKeysMock);
-
-	@Before
-	public void setUpMocks() {
-		when(traceeKeysMock.get()).thenReturn(traceeKeysSet);
-	}
-
-	@Test
-	public void putWritesEntryToKeysSet() {
-		unit.put("Foo", "bar");
-		verify(traceeKeysSet).add("Foo");
-	}
-
-	@Test
-	public void putWritesEntryToMdcLike() {
-		unit.put("Foo", "bar");
-		assertThat(unit.contextMap, hasEntry("Foo", "bar"));
-	}
-
-	@Test
-	public void putAllWritesEntriesToKeysSet() {
-		final Map<String, String> putMap = new HashMap<String, String>();
-		putMap.put("Foo", "bar");
-		putMap.put("Ping", "Pong");
-		unit.putAll(putMap);
-		verify(traceeKeysSet).add("Foo");
-		verify(traceeKeysSet).add("Ping");
-	}
-
-	@Test
-	public void putAllWritesEntriesToMdcLike() {
-		final Map<String, String> putMap = new HashMap<String, String>();
-		putMap.put("Foo", "bar");
-		putMap.put("Ping", "Pong");
-		unit.putAll(putMap);
-		assertThat(unit.contextMap, hasEntry("Foo", "bar"));
-		assertThat(unit.contextMap, hasEntry("Ping", "Pong"));
-		assertThat(unit.contextMap.size(), is(2));
-	}
-
-	@Test
-	public void clearAlsoRemovesTheThreadLocalTraceeKeys() {
-		when(traceeKeysSet.iterator()).thenReturn(Collections.<String>emptyList().iterator());
-		unit.clear();
-		verify(traceeKeysMock).remove();
-	}
-
-	@Test
-	public void clearRemovesRegisteredKeysFromMdcLike() {
-		traceeKeysSet.add("A");
-		traceeKeysSet.add("B");
-		unit.contextMap.put("A", "a");
-		unit.contextMap.put("B", "b");
-		unit.clear();
-		assertThat(unit.contextMap, not(hasEntry("A", "a")));
-		assertThat(unit.contextMap, not(hasEntry("B", "b")));
-	}
-
-	@Test
-	public void removeRemovesRegisteredKeysFromMDC() {
-		when(traceeKeysSet.remove("A")).thenReturn(true);
-		when(traceeKeysSet.contains("A")).thenReturn(true);
-		unit.contextMap.put("A", "a");
-		unit.remove("A");
-		assertThat(unit.contextMap.isEmpty(), is(true));
-	}
-
-	@Test
-	public void removeDoesNotRemoveUnregisteredKeysFromMDC() {
-		unit.contextMap.put("A", "a");
-		when(traceeKeysSet.remove("A")).thenReturn(false);
-		when(traceeKeysSet.contains("A")).thenReturn(false);
-		unit.remove("A");
-		assertThat(unit.contextMap, hasEntry("A", "a"));
-	}
-
-	@Test
-	public void sizeCorrespondsToStoredKeysSize() {
-		when(traceeKeysSet.size()).thenReturn(42);
-		assertThat(unit.size(), equalTo(42));
-	}
-
-	@Test
-	public void getValueFromMdcIfInKeySet() {
-		unit.contextMap.put("A", "hurray");
-		when(traceeKeysSet.contains("A")).thenReturn(true);
-		assertThat(unit.get("A"), equalTo("hurray"));
-	}
-
-	@Test
-	public void getDoesNotReadDirectlyFromMdcLike() {
-		unit.contextMap.put("A", "hurray");
-		when(traceeKeysSet.contains("A")).thenReturn(false);
-		assertThat(unit.get("A"), nullValue());
-	}
-
-	@Test
-	public void containsShouldReturnTrueIfInMDC() {
-		unit.contextMap.put("A", "hurray");
-		when(traceeKeysSet.contains("A")).thenReturn(true);
-		assertThat(unit.containsKey("A"), is(true));
-	}
-
-	@Test
-	public void containsShouldReturnFalseIfInKeysetButNotMDC() {
-		when(traceeKeysSet.contains("A")).thenReturn(true);
-		assertThat(unit.containsKey("A"), is(false));
-	}
-
-	@Test
-	public void isEmptyWhenKeySetIsEmpty() {
-		when(traceeKeysSet.isEmpty()).thenReturn(false);
-		assertThat(unit.isEmpty(), is(false));
-	}
-
-	@Test
-	public void copyToMapShouldCreateACopy() {
-		unit.contextMap.put("A","foo");
-		when(traceeKeysSet.iterator()).thenReturn(Collections.singleton("A").iterator());
-		final Map<String, String> copy = unit.copyToMap();
-		unit.remove("A");
-		assertThat(copy, hasEntry("A","foo"));
-	}
+	private final BackendBase unit = Mockito.spy(BackendBase.class);
 
 	@Test
 	public void invocationIdShortcutShouldReturnTheInvocationIdIfSet() {
-		unit.put(TraceeConstants.INVOCATION_ID_KEY, "ourInvocationId");
+		when(unit.get(eq(TraceeConstants.INVOCATION_ID_KEY))).thenReturn("ourInvocationId");
 		assertThat(unit.getInvocationId(), is("ourInvocationId"));
 	}
 
@@ -168,18 +36,13 @@ public class BackendBaseTest {
 
 	@Test
 	public void sessionIdShortcutShouldReturnTheSessionIdIfSet() {
-		unit.put(TraceeConstants.SESSION_ID_KEY, "ourSessionId");
+		when(unit.get(eq(TraceeConstants.SESSION_ID_KEY))).thenReturn("ourSessionId");
 		assertThat(unit.getSessionId(), is("ourSessionId"));
 	}
 
 	@Test
 	public void sessionIdShortcutShouldReturnNullIfNoSessionIdIsSet() {
 		assertThat(unit.getSessionId(), is(nullValue()));
-	}
-
-	@Test
-	public void containsShouldreturnFalseIfNotInMDC() {
-		assertThat(unit.containsKey("A"), is(false));
 	}
 
 	@Test
@@ -215,7 +78,7 @@ public class BackendBaseTest {
 	}
 
 
-		@Test
+	@Test
 	public void testDisabledProfile() {
 		assertThat(unit.getConfiguration(DISABLED).shouldProcessContext(Channel.AsyncDispatch), equalTo(false));
 		assertThat(unit.getConfiguration(DISABLED).shouldProcessContext(Channel.AsyncProcess), equalTo(false));
@@ -245,89 +108,5 @@ public class BackendBaseTest {
 	public void testProfileCacheForDifferenceProfiles() {
 		final TraceeFilterConfiguration hideInboundConfiguration = unit.getConfiguration(HIDE_OUTBOUND);
 		assertThat(unit.getConfiguration(HIDE_INBOUND), is(not(sameInstance(hideInboundConfiguration))));
-	}
-
-	class TestBackend extends BackendBase {
-
-		protected final ThreadLocal<Set<String>> traceeKeys;
-		public Map<String, String> contextMap = new HashMap<String, String>();
-
-		protected TestBackend(ThreadLocal<Set<String>> traceeKeys) {
-			this.traceeKeys = traceeKeys;
-		}
-
-		@Override
-        public boolean containsKey(String key) {
-			return key != null && traceeKeys.get().contains(key) && contextMap.get(key) != null;
-        }
-
-		@Override
-        public int size() {
-            return traceeKeys.get().size();
-        }
-
-		@Override
-        public boolean isEmpty() {
-            return traceeKeys.get().isEmpty();
-        }
-
-		@Override
-        public String get(String key) {
-            if ((key != null) && traceeKeys.get().contains(key))
-				return contextMap.get(key);
-            else
-                return null;
-        }
-
-		@Override
-        public void put(String key, String value) {
-            if (key == null) throw new NullPointerException("null keys are not allowed.");
-            if (value == null) throw new NullPointerException("null values are not allowed.");
-            final Set<String> registeredKeys = traceeKeys.get();
-            if (!registeredKeys.contains(key)) {
-                registeredKeys.add(key);
-            }
-			contextMap.put(key, value);
-		}
-
-		@Override
-        public void remove(String key) {
-            if (key == null) throw new NullPointerException("null keys are not allowed.");
-            if (traceeKeys.get().remove(key)) {
-				contextMap.remove(key);
-			}
-        }
-
-		/**
-         * Removes all tracee values from the underlying MDC and removes the thread local traceeKeys set.
-         */
-        @Override
-        public void clear() {
-            final Set<String> keys = new HashSet<String>(traceeKeys.get());
-            for (String key : keys) {
-                remove(key);
-            }
-            traceeKeys.remove();
-        }
-
-		@Override
-        public void putAll(Map<? extends String, ? extends String> entries) {
-            for (Map.Entry<? extends String, ? extends String> entry : entries.entrySet()) {
-                put(entry.getKey(), entry.getValue());
-            }
-        }
-
-		@Override
-        public Map<String, String> copyToMap() {
-            final Map<String, String> traceeMap = new HashMap<String, String>();
-            final Set<String> keys = traceeKeys.get();
-            for (String traceeKey : keys) {
-				final String value = contextMap.get(traceeKey);
-                if (value != null) {
-                    traceeMap.put(traceeKey, value);
-                }
-            }
-            return traceeMap;
-        }
 	}
 }

--- a/core/src/test/java/io/tracee/backend/slf4j/Slf4jMdcDelegationTest.java
+++ b/core/src/test/java/io/tracee/backend/slf4j/Slf4jMdcDelegationTest.java
@@ -1,6 +1,8 @@
 package io.tracee.backend.slf4j;
 
 import io.tracee.ThreadLocalHashSet;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,9 +11,20 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.MDC;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
@@ -24,8 +37,8 @@ public class Slf4jMdcDelegationTest {
 
 	@Before
 	public void setup() {
-		traceeKeys.get().add("BB");
 		PowerMockito.mockStatic(MDC.class);
+		traceeKeys.get().clear();
 	}
 
 	@Test
@@ -36,21 +49,120 @@ public class Slf4jMdcDelegationTest {
 	}
 
 	@Test
-	public void shouldReturnTrueIfKeyIsInMDC() {
+	public void putWritesEntryToKeysSet() {
+		unit.put("Foo", "bar");
+		assertThat(traceeKeys.get(), contains("Foo"));
+	}
+
+	@Test
+	public void putAllWritesEntriesToMdcLike() {
+		final Map<String, String> putMap = new HashMap<String, String>();
+		putMap.put("Foo", "bar");
+		putMap.put("Ping", "Pong");
+		unit.putAll(putMap);
+		PowerMockito.verifyStatic(times(1));
+		MDC.put(eq("Foo"), eq("bar"));
+		PowerMockito.verifyStatic(times(1));
+		MDC.put(eq("Ping"), eq("Pong"));
+		PowerMockito.verifyNoMoreInteractions(MDC.class);
+	}
+
+	@Test
+	public void putAllWritesEntriesToKeysSet() {
+		final Map<String, String> putMap = new HashMap<String, String>();
+		putMap.put("Foo", "bar");
+		putMap.put("Ping", "Pong");
+		unit.putAll(putMap);
+		assertThat(traceeKeys.get(), contains("Foo", "Ping"));
+	}
+
+	@Test
+	public void clearAlsoRemovesTheThreadLocalTraceeKeys() {
+		traceeKeys.get().add("test");
+		unit.clear();
+		verifyStatic(times(1));
+		MDC.remove("test");
+		PowerMockito.verifyNoMoreInteractions(MDC.class);
+	}
+
+	@Test
+	public void containsShouldReturnTrueIfInMdcAndKeySet() {
+		traceeKeys.get().add("BB");
 		when(MDC.get("BB")).thenReturn("vBB");
 		assertThat(unit.containsKey("BB"), is(true));
 	}
 
 	@Test
-	public void shouldReturnValueFromMDC() {
-		when(MDC.get("BB")).thenReturn("vBB");
-		assertThat(unit.get("BB"), equalTo("vBB"));
+	public void containsShouldReturnFalseIfInKeysetButNotMDC() {
+		traceeKeys.get().add("BB");
+		assertThat(unit.containsKey("BB"), is(false));
 	}
 
 	@Test
-	public void shouldCallRemoveOnMDC() {
+	public void containsShouldReturnFalseIfInMdcButNotInKeyset() {
+		when(MDC.get("BB")).thenReturn("vBB");
+		assertThat(unit.containsKey("BB"), is(false));
+	}
+
+	@Test
+	public void getValueFromMdcIfInKeySet() {
+		traceeKeys.get().add("A");
+		PowerMockito.when(MDC.get(eq("A"))).thenReturn("hurray");
+		assertThat(unit.get("A"), equalTo("hurray"));
+	}
+
+	@Test
+	public void getDoesNotReadFromMdcWhenKeyIsNotInKeySet() {
+		PowerMockito.when(MDC.get(eq("A"))).thenReturn("hurray");
+		assertThat(unit.get("A"), nullValue());
+	}
+
+	@Test
+	public void callOnRemoveShouldRemoveValueFromMDC() {
+		traceeKeys.get().add("BB");
 		unit.remove("BB");
 		PowerMockito.verifyStatic();
 		MDC.remove("BB");
+	}
+
+	@Test
+	public void callOnRemoveShouldRemoveValueFromTraceeKeys() {
+		traceeKeys.get().add("BB");
+		unit.remove("BB");
+		assertThat(traceeKeys.get(), empty());
+	}
+
+	@Test
+	public void removeDoesNotRemoveUnregisteredKeysFromMDC() {
+		unit.remove("A");
+		PowerMockito.verifyNoMoreInteractions(MDC.class);
+	}
+
+	@Test
+	public void sizeCorrespondsToStoredKeysSize() {
+		traceeKeys.get().addAll(Arrays.asList("A", "B", "C", "D"));
+		assertThat(unit.size(), equalTo(4));
+	}
+
+	@Test
+	public void isEmptyWhenKeySetIsEmptyRegardlessOfMDC() {
+		PowerMockito.when(MDC.get(eq("A"))).thenReturn("hurray");
+		assertThat(unit.isEmpty(), Matchers.is(true));
+	}
+
+	@Test
+	public void isNotEmptyIfKeySetContainsValuesRegardlessOfMDC() {
+		traceeKeys.get().add("A");
+		Assert.assertThat(unit.isEmpty(), is(false));
+	}
+
+	@Test
+	public void copyToMapShouldCreateACopy() {
+		PowerMockito.when(MDC.get(eq("A"))).thenReturn("AAb");
+		traceeKeys.get().add("A");
+
+		final Map<String, String> copyOfMdc = unit.copyToMap();
+		assertThat(copyOfMdc, hasEntry("A", "AAb"));
+		assertThat(copyOfMdc.size(), is(1));
 	}
 }


### PR DESCRIPTION
`BackendBaseTest` is testing alot of stuff of the `BackendBaseTest.TestBackend` class. This is kind of stupid: We're testing testcode that is only used in this test.
I've moved several testcases to test the `Slf4jTraceeBackend` and replaced the `TestBackend` with a simple Spy to test the abstract implementation, f.e. the configuration handling.