### PR TITLE
Remove final modifiers for #134

### DIFF
--- a/binding/jaxrs2/src/main/java/io/tracee/binding/jaxrs2/TraceeClientFilter.java
+++ b/binding/jaxrs2/src/main/java/io/tracee/binding/jaxrs2/TraceeClientFilter.java
@@ -36,7 +36,7 @@ public class TraceeClientFilter implements ClientRequestFilter, ClientResponseFi
 	 * This method handles the outgoing request
 	 */
 	@Override
-	public final void filter(final ClientRequestContext requestContext) {
+	public void filter(final ClientRequestContext requestContext) {
 		if (!backend.isEmpty() && backend.getConfiguration().shouldProcessContext(OutgoingRequest)) {
 			final Map<String, String> filtered = backend.getConfiguration().filterDeniedParams(backend.copyToMap(), OutgoingRequest);
 			requestContext.getHeaders().putSingle(TraceeConstants.TPIC_HEADER, transportSerialization.render(filtered));

--- a/binding/jaxrs2/src/main/java/io/tracee/binding/jaxrs2/TraceeContainerFilter.java
+++ b/binding/jaxrs2/src/main/java/io/tracee/binding/jaxrs2/TraceeContainerFilter.java
@@ -38,7 +38,7 @@ public class TraceeContainerFilter implements ContainerRequestFilter, ContainerR
 	 * This method handles the incoming request
 	 */
 	@Override
-	public final void filter(final ContainerRequestContext containerRequestContext) {
+	public void filter(final ContainerRequestContext containerRequestContext) {
 
 		if (backend.getConfiguration().shouldProcessContext(IncomingRequest)) {
 			final List<String> serializedTraceeHeaders = containerRequestContext.getHeaders().get(TraceeConstants.TPIC_HEADER);


### PR DESCRIPTION
This PR removes the final modifiers from the filter methods of TraceeClientFilter.java and TraceeContainerFilter.java in the jaxrs2 binding.