### PR TITLE
Use concret version in the markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,23 @@ Look into our [Bindings](binding/)-Page to get a more detailed binding overview.
 
 All TracEE modules are (hopefully) OSGI compliant.
 
-## Maven artifacts
+## Artifacts
 
-Tracee is released to maven central via Sonatype OSS Repository Hosting. Just add a maven/gradle/sbt dependency as usual. If you are a crazy one, you could use the very latest SNAPSHOT as well by adding the sonatype snapshot repository:
+In the same application TracEE modules should be compatible along the same minor version. Between independent applications the TPIC header should be handled without any adjustments along the same major version of TracEE. When using several TracEE modules you should consider using the [BOM](bom/) and create a property `tracee.version` in your maven project to ease dependency management. 
+
+### Repository
+
+Tracee is released to maven central via Sonatype OSS Repository Hosting. Maven users are able to use TracEE modules without any configuration simply by adding the dependency. Users of Gradle should add the maven central:
+
+```
+repositories {
+    mavenCentral()
+}
+```
+
+### Snapshot builds
+
+If you are a crazy one, you could use the very latest SNAPSHOT as well by adding the sonatype snapshot repository. For maven simple add:
 
 ```xml
 <repositories>
@@ -172,7 +186,23 @@ Tracee is released to maven central via Sonatype OSS Repository Hosting. Just ad
 </repositories>
 ```
 
-When you use several TracEE modules you should consider using the [BOM](bom/) in your maven project to ease dependency management.
+For gradle add it manually:
+
+```
+repositories {
+    maven {
+    	url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
+}
+```
+
+If you don't get the latest version you've to reduce the caching time of artifacts:
+
+```
+configurations.all {
+    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+}
+```
 
 # More
 

--- a/backend/threadlocal-store/README.md
+++ b/backend/threadlocal-store/README.md
@@ -14,7 +14,7 @@ You need exactly one backend provider on your runtime classpath. Add following t
 	<dependency>
 		<groupId>io.tracee.backend</groupId>
 		<artifactId>tracee-threadlocal-store</artifactId>
-		<version>RELEASE</version> <!-- You should specify a version instead -->
+		<version>${tracee.version}</version>
 		<scope>runtime</scope>
 	</dependency>
 ...

--- a/binding/cxf/README.md
+++ b/binding/cxf/README.md
@@ -14,7 +14,7 @@ Add to your CXF dependency for REST or SOAP our additional TracEE part. For exam
     <dependency>
         <groupId>io.tracee.binding</groupId>
         <artifactId>tracee-cxf</artifactId>
-        <version>RELEASE</version> <!-- You should specify a version instead -->
+        <version>${tracee.version}</version>
     </dependency>
 ...
 </dependencies>

--- a/binding/httpclient/README.md
+++ b/binding/httpclient/README.md
@@ -14,7 +14,7 @@ Add the `tracee-httpclient` module to your `pom.xml` dependencies:
     <dependency>
         <groupId>io.tracee.binding</groupId>
    		<artifactId>tracee-httpclient</artifactId>
-        <version>RELEASE</version>
+        <version>${tracee.version}</version>
     </dependency>
 ...
 </dependencies>

--- a/binding/httpcomponents/README.md
+++ b/binding/httpcomponents/README.md
@@ -17,7 +17,7 @@ This module contains two interceptors:
     <dependency>
         <groupId>io.tracee.binding</groupId>
    		<artifactId>tracee-httpcomponents</artifactId>
-        <version>RELEASE</version>
+        <version>${tracee.version}</version>
     </dependency>
 ...
 </dependencies>

--- a/binding/jaxrs2/README.md
+++ b/binding/jaxrs2/README.md
@@ -12,7 +12,7 @@ Please add the following dependency to enable TracEE JAX-RS 2.x ([JSR 339](http:
     <dependency>
         <groupId>io.tracee.binding</groupId>
         <artifactId>tracee-jaxrs2</artifactId>
-        <version>RELEASE</version> <!-- You should specify a version instead -->
+        <version>${tracee.version}</version>
     </dependency>
     ...
 </dependencies>

--- a/binding/jaxws/README.md
+++ b/binding/jaxws/README.md
@@ -12,7 +12,7 @@ Please add the following dependencies to enable TracEE JAX-WS support. For examp
     <dependency>
         <groupId>io.tracee.binding</groupId>
         <artifactId>tracee-jaxws</artifactId>
-        <version>RELEASE</version>
+        <version>${tracee.version}</version>
     </dependency>
     ...
 </dependencies>

--- a/binding/jms/README.md
+++ b/binding/jms/README.md
@@ -13,7 +13,7 @@ Please add the following dependencies to enable TracEE's JMS support. For exampl
     <dependency>
         <groupId>io.tracee.binding</groupId>
         <artifactId>tracee-jms</artifactId>
-        <version>RELEASE</version>
+        <version>${tracee.version}</version>
     </dependency>
     ...
 </dependencies>

--- a/binding/quartz/README.md
+++ b/binding/quartz/README.md
@@ -17,7 +17,7 @@ Use this module with Quartz 2.1 or above. Add this module as dependency. For Mav
     <dependency>
         <groupId>io.tracee.binding</groupId>
         <artifactId>tracee-quartz</artifactId>
-        <version>RELEASE</version>
+        <version>${tracee.version}</version>
     </dependency>
     ...
 </dependencies>

--- a/binding/servlet/README.md
+++ b/binding/servlet/README.md
@@ -20,7 +20,7 @@ If you're use Maven for your dependency management simple add this to your pom:
     <dependency>
         <groupId>io.tracee.binding</groupId>
         <artifactId>tracee-servlet</artifactId>
-        <version>RELEASE</version>
+        <version>${tracee.version}</version>
     </dependency>
 ...
 </dependencies>

--- a/binding/springhttpclient/README.md
+++ b/binding/springhttpclient/README.md
@@ -19,7 +19,7 @@ For maven you've to add following dependency to your `pom.xml`:
 <dependency>
 	<groupId>io.tracee.binding</groupId>
     <artifactId>tracee-springhttpclient</artifactId>
-    <version>RELEASE</version> <!-- You should specify a version instead -->
+    <version>${tracee.version}</version>
 </dependency>
 ...
 ```

--- a/binding/springmvc/README.md
+++ b/binding/springmvc/README.md
@@ -15,7 +15,7 @@ Add `tracee-springmvc` to your application dependencies. That's all! - For examp
     <dependency>
 	<groupId>io.tracee.binding</groupId>
 	<artifactId>tracee-springmvc</artifactId>
-    <version>RELEASE</version> <!-- You should specify a version instead -->
+    <version>${tracee.version}</version>
     </dependency>
 ...
 </dependencies>

--- a/binding/springrabbitmq/README.md
+++ b/binding/springrabbitmq/README.md
@@ -16,7 +16,7 @@ If you're use Maven for your dependency management simple add this to your pom:
     <dependency>
         <groupId>io.tracee.binding</groupId>
         <artifactId>tracee-springrabbitmq</artifactId>
-        <version>RELEASE</version> <!-- You should specify a version instead -->
+        <version>${tracee.version}</version>
     </dependency>
 ...
 </dependencies>

--- a/binding/springws/README.md
+++ b/binding/springws/README.md
@@ -14,7 +14,7 @@ Add the dependency to your classpath. If you're using Apache Maven, you could us
 	<dependency>
 		<groupId>io.tracee.binding</groupId>
 		<artifactId>tracee-springws</artifactId>
-		<version>RELEASE</version> <!-- You should specify a version instead -->
+		<version>${tracee.version}</version>
 	</dependency>
 ...
 </dependencies>

--- a/bom/README.md
+++ b/bom/README.md
@@ -12,7 +12,7 @@ Add this BOM to your parent `pom.xml`:
         <dependency>
             <groupId>io.tracee</groupId>
             <artifactId>tracee-bom</artifactId>
-            <version>RELEASE</version> <!-- You should specify a version instead -->
+            <version>${tracee.version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>


### PR DESCRIPTION
Use concret version in the documentation to be compatible with Maven 3.
We strongly suggest to create a version property. Due the limitation of markdown properties we point to the property `tracee.version` in the module documentations.