### PR TITLE
WIP: PoC of new Spring-JMS binding

### DIFF
--- a/binding/springjms/README.md
+++ b/binding/springjms/README.md
@@ -1,0 +1,39 @@
+> This document contains documentation for the `tracee-springjms` module. Check the [TracEE main documentation](/README.md) to get started.
+
+# tracee-springjms
+
+> This module contains all necessary classes to add the TPIC to all produced messages and read if from it in case of consuming.
+
+ * __TraceeMessageConverter__: A `MessageConverter` that defaults to Springs `SimpleMessageConverter` but with wrapping ability.
+ 
+## Installation
+
+To use the `org.springframework.jms.support.converter.SimpleMessageConverter` of Spring which is the default implementation for all transformations simple configure the `TraceeMessageConverter` this way:
+
+```xml
+  <bean id="traceeMessageConverter" class="io.tracee.binding.springjms.TraceeMessageConverter" />
+  <bean id="jmsTemplate" class="org.springframework.jms.core.JmsTemplate" p:messageConverter-ref="traceeMessageConverter"/>
+```
+
+If you like to use your own MessageConverter `foo.bar.FooBarConverter` use the wrapping functionality of the `TraceeMessageConverter`:
+
+```xml
+  <bean id="traceeMessageConverter" class="io.tracee.binding.springjms.TraceeMessageConverter">
+    <constructor-arg>
+      <bean class="foo.bar.FooBarConverter" />
+    </constructor-arg>
+  </bean>
+  <bean id="jmsTemplate" class="org.springframework.jms.core.JmsTemplate" p:messageConverter-ref="traceeMessageConverter"/>
+```
+
+That's it!
+
+### Manual message creation / consumption
+
+If you read / write JMS messages without a `MessageConverter` you've to read / write the TPIC to your messages by yourself. Please refer following methods:
+
+* Reading TPIC from a message: `JmsHelper.readTpicFromMessage(message)`
+* Write TPIC to a message: `JmsHelper.writeTpicToMessage(message)`
+* Clean the TPIC from the Thread after the processing: `Tracee.getBackend().clear()`
+
+You should use this helper methods within your implementation of the `MessageCreator` or `MessageListener`.

--- a/binding/springjms/pom.xml
+++ b/binding/springjms/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.tracee.binding</groupId>
+	<artifactId>tracee-springjms</artifactId>
+	<packaging>bundle</packaging>
+	<properties>
+		<activemq.version>5.10.2</activemq.version>
+	</properties>
+
+	<parent>
+		<groupId>io.tracee</groupId>
+		<artifactId>tracee-parent</artifactId>
+		<version>1.1.2-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<name>tracee-springjms</name>
+	<description>Please refer to https://github.com/tracee/tracee.</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.tracee</groupId>
+			<artifactId>tracee-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.tracee</groupId>
+			<artifactId>tracee-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.jms</groupId>
+			<artifactId>jms-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jms</artifactId>
+			<version>${spring.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-spring</artifactId>
+			<version>${activemq.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-broker</artifactId>
+			<version>${activemq.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.tracee.binding</groupId>
+			<artifactId>tracee-jms</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.tracee</groupId>
+			<artifactId>tracee-testhelper</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/binding/springjms/src/main/java/io/tracee/binding/springjms/JmsHelper.java
+++ b/binding/springjms/src/main/java/io/tracee/binding/springjms/JmsHelper.java
@@ -1,0 +1,49 @@
+package io.tracee.binding.springjms;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.TraceeConstants;
+import io.tracee.Utilities;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import java.util.Map;
+
+import static io.tracee.configuration.TraceeFilterConfiguration.Channel.AsyncDispatch;
+import static io.tracee.configuration.TraceeFilterConfiguration.Channel.AsyncProcess;
+
+/**
+ * For manual reading / writing from/to messages
+ */
+public class JmsHelper {
+
+	@SuppressWarnings("unused")
+	public static void readTpicFromMessage(final Message message) throws JMSException {
+		readTpicFromMessage(message, Tracee.getBackend());
+	}
+
+	public static void readTpicFromMessage(final Message message, final TraceeBackend backend) throws JMSException {
+		if (message != null && backend.getConfiguration().shouldProcessContext(AsyncProcess)) {
+			final Object encodedTraceeContext = message.getObjectProperty(TraceeConstants.TPIC_HEADER);
+			if (encodedTraceeContext != null) {
+				@SuppressWarnings("unchecked")
+				final Map<String, String> contextFromMessage = (Map<String, String>) encodedTraceeContext;
+				backend.putAll(backend.getConfiguration().filterDeniedParams(contextFromMessage, AsyncProcess));
+			}
+		}
+
+		Utilities.generateInvocationIdIfNecessary(backend);
+	}
+
+	@SuppressWarnings("unused")
+	public static void writeTpicToMessage(final Message message) throws JMSException {
+		writeTpicToMessage(message, Tracee.getBackend());
+	}
+
+	public static void writeTpicToMessage(final Message message, final TraceeBackend backend) throws JMSException {
+		if (!backend.isEmpty() && backend.getConfiguration().shouldProcessContext(AsyncDispatch) && message != null) {
+			final Map<String, String> filteredContext = backend.getConfiguration().filterDeniedParams(backend.copyToMap(), AsyncDispatch);
+			message.setObjectProperty(TraceeConstants.TPIC_HEADER, filteredContext);
+		}
+	}
+}

--- a/binding/springjms/src/main/java/io/tracee/binding/springjms/TraceeMessageConverter.java
+++ b/binding/springjms/src/main/java/io/tracee/binding/springjms/TraceeMessageConverter.java
@@ -1,0 +1,54 @@
+package io.tracee.binding.springjms;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import org.springframework.jms.support.converter.MessageConversionException;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.jms.support.converter.SimpleMessageConverter;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+
+public class TraceeMessageConverter implements MessageConverter {
+
+	private final MessageConverter delegate;
+
+	private final TraceeBackend backend;
+
+	public TraceeMessageConverter() {
+		this.delegate = new SimpleMessageConverter();
+		this.backend = Tracee.getBackend();
+	}
+
+	public TraceeMessageConverter(MessageConverter delegate) {
+		this.delegate = delegate;
+		this.backend = Tracee.getBackend();
+	}
+
+	TraceeMessageConverter(MessageConverter converter, TraceeBackend backend) {
+		this.delegate = converter;
+		this.backend = backend;
+	}
+
+	@Override
+	public Message toMessage(Object o, Session session) throws JMSException, MessageConversionException {
+		final Message message = delegate.toMessage(o, session);
+
+		JmsHelper.writeTpicToMessage(message, backend);
+
+		return message;
+	}
+
+	@Override
+	public Object fromMessage(Message message) throws JMSException, MessageConversionException {
+
+		// Spring doesn't offer a whole transaction where we can hook into. So let's clean before the next message an hope, that the cached
+		// consumer holds the thread. Otherwise the TPIC is used for other processing. - But I've not idea how we could avoid this.
+		backend.clear();
+
+		JmsHelper.readTpicFromMessage(message, backend);
+
+		return delegate.fromMessage(message);
+	}
+}

--- a/binding/springjms/src/test/java/io/tracee/binding/springjms/JmsHelperTest.java
+++ b/binding/springjms/src/test/java/io/tracee/binding/springjms/JmsHelperTest.java
@@ -1,0 +1,69 @@
+package io.tracee.binding.springjms;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.TraceeConstants;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JmsHelperTest {
+
+	private final Message message = mock(Message.class);
+
+	private final TraceeBackend backend = Tracee.getBackend();
+
+	@Before
+	public void setup() {
+		backend.clear();
+		backend.put("ourTestKey", "Foo321");
+	}
+
+	@Test
+	public void shouldHandleNullMessagesOnReadingWithoutException() throws JMSException {
+		JmsHelper.readTpicFromMessage(null);
+	}
+
+	@Test
+	public void shouldHandleNullMessagesOnWritingWithoutException() throws JMSException {
+		JmsHelper.writeTpicToMessage(null);
+	}
+
+	@Test
+	public void writeTpicToMessage() throws JMSException {
+		JmsHelper.writeTpicToMessage(message, backend);
+		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), eq(backend.copyToMap()));
+	}
+
+	@Test
+	public void readTpicFromMessage() throws JMSException {
+		final Map<String, String> testTpic = new HashMap<String, String>();
+		testTpic.put("myTestKey", "myTestval32");
+
+		when(message.getObjectProperty(eq(TraceeConstants.TPIC_HEADER))).thenReturn(testTpic);
+		JmsHelper.readTpicFromMessage(message, backend);
+		assertThat(backend.copyToMap(), hasEntry("myTestKey", "myTestval32"));
+	}
+
+	@Test
+	public void createInvocationIdIfNoInvocationIdCouldBeReadFromMessage() throws JMSException {
+		final Map<String, String> testTpic = new HashMap<String, String>();
+		testTpic.put("myTestKey", "myTestval32");
+
+		when(message.getObjectProperty(eq(TraceeConstants.TPIC_HEADER))).thenReturn(testTpic);
+		JmsHelper.readTpicFromMessage(message, backend);
+		assertThat(backend.getInvocationId().length(), is(32));
+	}
+}

--- a/binding/springjms/src/test/java/io/tracee/binding/springjms/TraceeMessageConverterIT.java
+++ b/binding/springjms/src/test/java/io/tracee/binding/springjms/TraceeMessageConverterIT.java
@@ -1,0 +1,85 @@
+package io.tracee.binding.springjms;
+
+import io.tracee.Tracee;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.tracee.TraceeConstants.TPIC_HEADER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:/test-context.xml")
+public class TraceeMessageConverterIT {
+
+	private static final String TEST_DESTINATION = "testDestination";
+
+	@Autowired
+	private JmsTemplate jmsTemplate;
+
+	@Before
+	public void setup() {
+		Tracee.getBackend().clear();
+	}
+
+	@Test
+	public void shouldAddTpicToMessage() throws JMSException {
+		Tracee.getBackend().put("integrationTestKey", "ourVal");
+		jmsTemplate.convertAndSend(TEST_DESTINATION, "Our test message");
+
+		final Message consumedMessage = jmsTemplate.receive(TEST_DESTINATION);
+		@SuppressWarnings("unchecked")
+		final Map<String, String> tpicMap = (Map<String, String>) consumedMessage.getObjectProperty(TPIC_HEADER);
+		assertThat(tpicMap, hasEntry("integrationTestKey", "ourVal"));
+	}
+
+	@Test
+	public void shouldReadTpicFromMesage() throws JMSException {
+		jmsTemplate.send(TEST_DESTINATION, new MessageCreator() {
+			@Override
+			public Message createMessage(Session session) throws JMSException {
+				final TextMessage message = session.createTextMessage("Receive this!");
+				final Map<String, String> messageTpic = new HashMap<String, String>();
+				messageTpic.put("receiveThisKey!", "receiveThisAndDoWhatYouWand!");
+				message.setObjectProperty(TPIC_HEADER, messageTpic);
+				return message;
+			}
+		});
+
+		jmsTemplate.receiveAndConvert(TEST_DESTINATION);
+		assertThat(Tracee.getBackend().copyToMap(), hasEntry("receiveThisKey!", "receiveThisAndDoWhatYouWand!"));
+	}
+
+	@Test
+	public void ensureInvocationIdIsCreatedIfNoInvocationIdIsReceived() {
+		assertThat(Tracee.getBackend().getInvocationId(), is(nullValue()));
+
+		jmsTemplate.send(TEST_DESTINATION, new MessageCreator() {
+			@Override
+			public Message createMessage(Session session) throws JMSException {
+				return session.createTextMessage("Message without invocation Id");
+			}
+		});
+
+		final String receivedMessage = (String) jmsTemplate.receiveAndConvert(TEST_DESTINATION);
+		assertThat(receivedMessage, is("Message without invocation Id"));
+
+		assertThat(Tracee.getBackend().getInvocationId().length(), is(32));
+	}
+}

--- a/binding/springjms/src/test/java/io/tracee/binding/springjms/TraceeMessageConverterTest.java
+++ b/binding/springjms/src/test/java/io/tracee/binding/springjms/TraceeMessageConverterTest.java
@@ -1,0 +1,75 @@
+package io.tracee.binding.springjms;
+
+import io.tracee.TraceeBackend;
+import io.tracee.testhelper.SimpleTraceeBackend;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Matchers;
+import org.springframework.jms.support.converter.MessageConverter;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.tracee.TraceeConstants.TPIC_HEADER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TraceeMessageConverterTest {
+
+	private final MessageConverter messageConverter = mock(MessageConverter.class);
+
+	private final TraceeBackend backend = spy(SimpleTraceeBackend.createNonLoggingAllPermittingBackend());
+
+	private final TraceeMessageConverter UNIT = new TraceeMessageConverter(messageConverter, backend);
+
+	private final Message message = mock(Message.class);
+
+	@Before
+	public void setup() throws JMSException {
+		when(messageConverter.toMessage(any(), any(Session.class))).thenReturn(message);
+	}
+
+	@Test
+	public void cleanBackendBeforeAddingNewValues() throws JMSException {
+		final Map<String, String> tpicOfMessage = new HashMap<String, String>();
+		tpicOfMessage.put("keyOfTpic", "Val654");
+		when(message.getObjectProperty(TPIC_HEADER)).thenReturn(tpicOfMessage);
+
+		UNIT.fromMessage(message);
+		final InOrder inOrder = inOrder(backend, message);
+
+		inOrder.verify(backend).clear();
+		inOrder.verify(message).getObjectProperty(eq(TPIC_HEADER));
+		inOrder.verify(backend).putAll(anyMapOf(String.class, String.class));
+	}
+
+	@Test
+	public void writeTpicOfBackendIntoMessageOfDelegate() throws JMSException {
+		backend.put("myTestK", "superVal");
+		final Message message = UNIT.toMessage(null, null);
+
+		verify(message).setObjectProperty(eq(TPIC_HEADER), Matchers.anyMapOf(String.class, String.class));
+	}
+
+	@Test
+	public void readTpicFromMessage() throws JMSException {
+		final Map<String, String> tpicOfMessage = new HashMap<String, String>();
+		tpicOfMessage.put("keyOfTpic", "Val654");
+		when(message.getObjectProperty(TPIC_HEADER)).thenReturn(tpicOfMessage);
+
+		UNIT.fromMessage(message);
+
+		assertThat(backend.copyToMap(), org.hamcrest.Matchers.hasEntry("keyOfTpic", "Val654"));
+	}
+}

--- a/binding/springjms/src/test/resources/test-context.xml
+++ b/binding/springjms/src/test/resources/test-context.xml
@@ -1,0 +1,36 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	   xmlns:amq="http://activemq.apache.org/schema/core"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans.xsd http://activemq.apache.org/schema/core
+                           http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+	<amq:broker id="broker" useJmx="false" persistent="false">
+		<amq:transportConnectors>
+			<amq:transportConnector uri="tcp://localhost:0"/>
+		</amq:transportConnectors>
+	</amq:broker>
+
+	<amq:queue id="destination" physicalName="myTestQueue"/>
+
+	<!-- JMS ConnectionFactory to use, configuring the embedded broker using XML -->
+	<amq:connectionFactory id="jmsFactory" brokerURL="vm://localhost"/>
+
+	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+		<property name="targetConnectionFactory" ref="jmsFactory"/>
+		<property name="reconnectOnException" value="true" />
+	</bean>
+
+	<bean id="jmsContainer" class="org.springframework.jms.listener.SimpleMessageListenerContainer">
+		<property name="connectionFactory" ref="connectionFactory"/>
+		<property name="destination" ref="destination" />
+	</bean>
+
+	<bean id="traceeMessageConverter" class="io.tracee.binding.springjms.TraceeMessageConverter"/>
+
+	<bean id="jmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+		<property name="messageConverter" ref="traceeMessageConverter" />
+		<property name="connectionFactory" ref="connectionFactory" />
+	</bean>
+
+</beans>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -96,6 +96,11 @@
                 <artifactId>tracee-springws</artifactId>
                 <version>${project.version}</version>
             </dependency>
+			<dependency>
+				<groupId>io.tracee.binding</groupId>
+				<artifactId>tracee-springjms</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 
             <!-- test utils -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <module>binding/springrabbitmq</module>
         <module>binding/quartz</module>
         <module>binding/springws</module>
+		<module>binding/springjms</module>
 
         <!-- BOM (Bill Of Materials) -->
         <module>bom</module>
@@ -491,6 +492,12 @@
                 <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-simple</artifactId>
+				<version>${slf4j.version}</version>
+				<scope>test</scope>
+			</dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-api-mockito</artifactId>


### PR DESCRIPTION
A PoC of spring JMS implementation. It ships an own version of a `MessageConverter` with some wrapping/delegation ability if the user want use an own implementation.

On the receiving site it's not possible to get the end of the invocation without wrapping all of the API (like in #143 ) but when I get the manual of Spring JMS right, the consumers are cached in an own threadpool. So it's possible to clean the threads right before the next job I think. 

(Maybe we can create some interoperability tests between JMS and SpringJMS. But there is no implementation of a message and bad practice to mock the whole message if we want to test some interoperability.)