### PR TITLE
Resolve #129: Use Java7 in TracEE 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
   directories:
   - $HOME/.m2
 jdk:
-- openjdk6
 - openjdk7
 - oraclejdk8
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>io.tracee</groupId>
 		<artifactId>tracee-parent</artifactId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<name>tracee-api</name>

--- a/backend/threadlocal-store/pom.xml
+++ b/backend/threadlocal-store/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/binding/cxf/pom.xml
+++ b/binding/cxf/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<artifactId>tracee-parent</artifactId>
 		<groupId>io.tracee</groupId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/binding/httpclient/pom.xml
+++ b/binding/httpclient/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/binding/httpcomponents/pom.xml
+++ b/binding/httpcomponents/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/binding/jaxrs2/pom.xml
+++ b/binding/jaxrs2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/binding/jaxws/pom.xml
+++ b/binding/jaxws/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/binding/jms/pom.xml
+++ b/binding/jms/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/binding/quartz/pom.xml
+++ b/binding/quartz/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<artifactId>tracee-parent</artifactId>
 		<groupId>io.tracee</groupId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/binding/servlet/pom.xml
+++ b/binding/servlet/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/binding/springhttpclient/pom.xml
+++ b/binding/springhttpclient/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>tracee-parent</artifactId>
 		<groupId>io.tracee</groupId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/binding/springmvc/pom.xml
+++ b/binding/springmvc/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>tracee-parent</artifactId>
         <groupId>io.tracee</groupId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/binding/springrabbitmq/pom.xml
+++ b/binding/springrabbitmq/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tracee-parent</artifactId>
 		<groupId>io.tracee</groupId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/binding/springws/pom.xml
+++ b/binding/springws/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>tracee-parent</artifactId>
 		<groupId>io.tracee</groupId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>tracee-parent</artifactId>
         <groupId>io.tracee</groupId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tracee-bom</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <name>tracee-core</name>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.tracee</groupId>
             <artifactId>tracee-api</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
 		<dependency>
 			<groupId>io.tracee</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.tracee</groupId>
     <artifactId>tracee-parent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -239,13 +239,10 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.5.1</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
-                        <compilerArguments>
-                            <Werror />
-                        </compilerArguments>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -278,7 +275,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>2.5.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>

--- a/testhelper/pom.xml
+++ b/testhelper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <name>tracee-testhelper</name>


### PR DESCRIPTION
Initial commit for TracEE 2.0
* Raise the version up to 2.0.0-SNAPSHOT
* Use Java7 instead of Java6.