### PR TITLE
TracEE 2: Upgrade Jetty to 8.1.x and use the same version in all TracEE modules

### DIFF
--- a/binding/httpclient/pom.xml
+++ b/binding/httpclient/pom.xml
@@ -39,8 +39,6 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>7.3.0.v20110203</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.tracee.backend</groupId>

--- a/binding/httpcomponents/pom.xml
+++ b/binding/httpcomponents/pom.xml
@@ -39,8 +39,6 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>7.3.0.v20110203</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.tracee.backend</groupId>

--- a/binding/servlet/pom.xml
+++ b/binding/servlet/pom.xml
@@ -26,10 +26,10 @@
 			<artifactId>tracee-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-        <dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-        </dependency>
+			<artifactId>javax.servlet-api</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>io.tracee</groupId>
 			<artifactId>tracee-testhelper</artifactId>
@@ -49,8 +49,6 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>7.3.0.v20110203</version>
-			<scope>test</scope>
 		</dependency>
     </dependencies>
 </project>

--- a/binding/servlet/src/test/java/io/tracee/binding/servlet/TraceeFilterIT.java
+++ b/binding/servlet/src/test/java/io/tracee/binding/servlet/TraceeFilterIT.java
@@ -7,7 +7,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.eclipse.jetty.server.DispatcherType;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.hamcrest.Matchers;
@@ -15,6 +14,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;

--- a/binding/servlet/src/test/java/io/tracee/binding/servlet/TraceeServletRequestListenerTest.java
+++ b/binding/servlet/src/test/java/io/tracee/binding/servlet/TraceeServletRequestListenerTest.java
@@ -18,6 +18,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestEvent;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -25,6 +26,7 @@ import static io.tracee.TraceeConstants.INVOCATION_ID_KEY;
 import static io.tracee.TraceeConstants.SESSION_ID_KEY;
 import static io.tracee.configuration.TraceeFilterConfiguration.Channel.IncomingRequest;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.enumeration;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
@@ -53,7 +55,8 @@ public class TraceeServletRequestListenerTest {
 	@Test
 	public void testGeneratesInvocationId() throws Exception {
 		when(configuration.shouldGenerateInvocationId()).thenReturn(true);
-		when(httpServletRequest.getHeaders(TraceeConstants.TPIC_HEADER)).thenReturn(Collections.enumeration(emptyList()));
+		final Collection<String> emptyList = Collections.emptyList();
+		when(httpServletRequest.getHeaders(TraceeConstants.TPIC_HEADER)).thenReturn(enumeration(emptyList));
 
 		unit.requestInitialized(wrapToEvent(httpServletRequest));
 		verify(backend, atLeastOnce()).put(eq(TraceeConstants.INVOCATION_ID_KEY), anyString());
@@ -62,7 +65,8 @@ public class TraceeServletRequestListenerTest {
 	@Test
 	public void testDoesNotGeneratesInvocationId() throws Exception {
 		when(configuration.shouldGenerateInvocationId()).thenReturn(false);
-		when(httpServletRequest.getHeaders(TraceeConstants.TPIC_HEADER)).thenReturn(Collections.enumeration(emptyList()));
+		final Collection<String> emptyList = Collections.emptyList();
+		when(httpServletRequest.getHeaders(TraceeConstants.TPIC_HEADER)).thenReturn(enumeration(emptyList));
 
 		unit.requestInitialized(wrapToEvent(httpServletRequest));
 		verify(backend, never()).put(eq(TraceeConstants.INVOCATION_ID_KEY), anyString());
@@ -79,7 +83,7 @@ public class TraceeServletRequestListenerTest {
 				return invocation.getArguments()[0];
 			}
 		});
-		when(httpServletRequest.getHeaders(TraceeConstants.TPIC_HEADER)).thenReturn(Collections.enumeration(
+		when(httpServletRequest.getHeaders(TraceeConstants.TPIC_HEADER)).thenReturn(enumeration(
 				singletonList(INVOCATION_ID_KEY + "=123")));
 
 		unit.requestInitialized(wrapToEvent(httpServletRequest));

--- a/binding/springhttpclient/pom.xml
+++ b/binding/springhttpclient/pom.xml
@@ -45,8 +45,6 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>7.3.0.v20110203</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.tracee.backend</groupId>

--- a/binding/springmvc/pom.xml
+++ b/binding/springmvc/pom.xml
@@ -27,10 +27,10 @@
             <artifactId>tracee-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
@@ -56,8 +56,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>7.3.0.v20110203</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>

--- a/binding/springmvc/src/test/java/io/tracee/binding/springmvc/TraceeInterceptorTest.java
+++ b/binding/springmvc/src/test/java/io/tracee/binding/springmvc/TraceeInterceptorTest.java
@@ -49,7 +49,7 @@ public class TraceeInterceptorTest {
 	public void beforeTest() {
 		mockedBackend = mockedBackend(new PermitAllTraceeFilterConfiguration());
 		unit = new TraceeInterceptor(mockedBackend);
-		when(httpServletRequest.getHeaders(TraceeConstants.TPIC_HEADER)).thenReturn(EmptyEnumeration.emptyEnumeration());
+		when(httpServletRequest.getHeaders(TraceeConstants.TPIC_HEADER)).thenReturn(EmptyEnumeration.<String>emptyEnumeration());
 	}
 
 	@Test

--- a/binding/springws/pom.xml
+++ b/binding/springws/pom.xml
@@ -120,8 +120,6 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>7.3.0.v20110203</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.sun.xml.ws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
 		<powermock.version>1.6.2</powermock.version>
 		<equalsverifier.version>1.7.5</equalsverifier.version>
 		<junit-benchmarks.version>0.7.2</junit-benchmarks.version>
+		<jetty.version>8.1.18.v20150929</jetty.version>
 
         <!-- dependency versions -->
         <slf4j.version>1.7.16</slf4j.version>
@@ -305,7 +306,7 @@
                 <plugin>
                     <groupId>org.mortbay.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>8.1.15.v20140411</version>
+                    <version>${jetty.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -427,10 +428,10 @@
                 <version>${slf4j.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
+			<dependency>
+				<groupId>javax.servlet</groupId>
+				<artifactId>javax.servlet-api</artifactId>
+                <version>3.0.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -524,6 +525,12 @@
                 <version>${log4j2.version}</version>
                 <scope>test</scope>
             </dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-servlet</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
+			</dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
Let's move to Servlet-API 3.0 and Jetty 8.
In TracEE 1.x different Jetty versions have been used in different modules. With this PR I've added a variable in the parent pom and extracted the `jetty-servlet` dependency definition.