### PR TITLE
TracEE 2: Upgrade to the latest Log4J versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,8 @@
 
         <!-- dependency versions -->
         <slf4j.version>1.7.16</slf4j.version>
-        <log4j.version>1.2.4</log4j.version>
-        <log4j2.version>2.0.2</log4j2.version>
+        <log4j.version>1.2.17</log4j.version>
+        <log4j2.version>2.5</log4j2.version>
         <logback.version>1.1.5</logback.version>
         <spring.version>3.2.14.RELEASE</spring.version>
     </properties>


### PR DESCRIPTION
Use the latest version of the legecy Log4J (1.2.17) and the newest one of Log4J2 (they release so often, when we'll release TracEE 2.0 this will be an old one ;-) ).
Both are still compatible to their major versions.