### PR TITLE
TracEE 2: Reworked the quartz module. Updated quartz to 2.2.2

### DIFF
--- a/binding/quartz/README.md
+++ b/binding/quartz/README.md
@@ -52,3 +52,7 @@ It could be the case that you use quartz to continue your invocation processing 
 new TraceeContextInjector().injectContext(trigger);
 ...
 ```
+
+(You could think "Why doesn't TracEE use the `SchedulerListener` to add the TPIC to new created jobs?" In general you're right, we're able to change
+the `JobDataMap` to store the TPIC to the job. Unfortunately the job isn't saved again after the modification. Due this restriction we've to
+add the TPIC before, otherwise the TPIC isn't saved.)

--- a/binding/quartz/pom.xml
+++ b/binding/quartz/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>io.tracee.binding</groupId>
@@ -17,7 +18,7 @@
 	<description>Please refer to https://github.com/tracee/tracee.</description>
 
 	<properties>
-		<quartz.version>2.1.7</quartz.version>
+		<quartz.version>2.2.2</quartz.version>
 	</properties>
 
 	<dependencies>

--- a/binding/quartz/src/main/java/io/tracee/binding/quartz/TraceeContextInjector.java
+++ b/binding/quartz/src/main/java/io/tracee/binding/quartz/TraceeContextInjector.java
@@ -11,6 +11,9 @@ import org.quartz.Trigger;
 
 import static io.tracee.configuration.TraceeFilterConfiguration.Channel.AsyncDispatch;
 
+/**
+ * This class injects the current TPIC into the `JobDataMap` at the time when a dynamic generated job is scheduled.
+ */
 public class TraceeContextInjector {
 
 	private final TraceeBackend backend;

--- a/binding/quartz/src/main/java/io/tracee/binding/quartz/TraceeJobListener.java
+++ b/binding/quartz/src/main/java/io/tracee/binding/quartz/TraceeJobListener.java
@@ -14,6 +14,11 @@ import java.util.Map;
 
 import static io.tracee.configuration.TraceeFilterConfiguration.Channel.AsyncProcess;
 
+/**
+ * Generates a invocation Id and clears the backend after the job has finished or aborted in an ungraceful way.
+ * <p/>
+ * This class is thread-safe.
+ */
 public class TraceeJobListener extends JobListenerSupport {
 
 	private final TraceeBackend backend;

--- a/binding/quartz/src/test/java/io/tracee/binding/quartz/TraceeContextInjectorTest.java
+++ b/binding/quartz/src/test/java/io/tracee/binding/quartz/TraceeContextInjectorTest.java
@@ -1,14 +1,17 @@
 package io.tracee.binding.quartz;
 
 import io.tracee.Tracee;
-import io.tracee.testhelper.FieldAccessUtil;
-import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.configuration.TraceeFilterConfiguration.Profile;
+import io.tracee.testhelper.FieldAccessUtil;
+import io.tracee.testhelper.SimpleTraceeBackend;
 import org.junit.Test;
+import org.quartz.Job;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 
@@ -55,7 +58,7 @@ public class TraceeContextInjectorTest {
 	@Test
 	public void addTpicHeaderToJobDataMapOfJobDetailsIfBackendContainsValues() {
 		backend.put("testKey", "testValue");
-		final JobDetail jobDetail = JobBuilder.newJob().build();
+		final JobDetail jobDetail = JobBuilder.newJob(NoopJob.class).build();
 		unit.injectContext(jobDetail);
 		assertThat(jobDetail.getJobDataMap(), hasKey(TPIC_HEADER));
 		assertThat((Map<String, String>) jobDetail.getJobDataMap().get(TPIC_HEADER), hasEntry("testKey", "testValue"));
@@ -77,5 +80,12 @@ public class TraceeContextInjectorTest {
 	public void constructorStoresProfileNameInternal() {
 		final TraceeContextInjector injector = new TraceeContextInjector("testProf");
 		assertThat((String) FieldAccessUtil.getFieldVal(injector, "profile"), is("testProf"));
+	}
+
+	static class NoopJob implements Job {
+		@Override
+		public void execute(JobExecutionContext context) throws JobExecutionException {
+			// noop
+		}
 	}
 }

--- a/binding/quartz/src/test/java/io/tracee/binding/quartz/TraceeJobListenerIT.java
+++ b/binding/quartz/src/test/java/io/tracee/binding/quartz/TraceeJobListenerIT.java
@@ -1,8 +1,8 @@
 package io.tracee.binding.quartz;
 
-import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeConstants;
 import io.tracee.configuration.TraceeFilterConfiguration.Profile;
+import io.tracee.testhelper.SimpleTraceeBackend;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/binding/quartz/src/test/java/io/tracee/binding/quartz/TraceeJobListenerTest.java
+++ b/binding/quartz/src/test/java/io/tracee/binding/quartz/TraceeJobListenerTest.java
@@ -1,11 +1,11 @@
 package io.tracee.binding.quartz;
 
 import io.tracee.Tracee;
-import io.tracee.testhelper.FieldAccessUtil;
-import io.tracee.testhelper.SimpleTraceeBackend;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
 import io.tracee.configuration.TraceeFilterConfiguration.Profile;
+import io.tracee.testhelper.FieldAccessUtil;
+import io.tracee.testhelper.SimpleTraceeBackend;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.quartz.JobDataMap;
@@ -85,6 +85,4 @@ public class TraceeJobListenerTest {
 	public void returnTheNameOfTheListener() {
 		assertThat(unit.getName(), is("TracEE job listener"));
 	}
-
-
 }


### PR DESCRIPTION
I've checked the listeners for a better integration in case of writing the jobs to the queue. But nothing have changed: Modified jobs aren't saved again into the queue, so the TPIC is lost if the queue isn't stored locally / inmemory.