### PR TITLE
Small update of httpcomponents

### DIFF
--- a/binding/httpcomponents/README.md
+++ b/binding/httpcomponents/README.md
@@ -26,7 +26,8 @@ This module contains two interceptors:
 Then add simply two interceptors to your HttpClient of the httpcomponents module:
 
 ```java
-DefaultHttpClient httpClient = new DefaultHttpClient();
-httpClient.addRequestInterceptor(new TraceeHttpRequestInterceptor());
-httpClient.addResponseInterceptor(new TraceeHttpResponseInterceptor());
+HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+httpClientBuilder.addInterceptorLast(new TraceeHttpRequestInterceptor());
+httpClientBuilder.addInterceptorFirst(new TraceeHttpResponseInterceptor());
+CloseableHttpClient httpClient = httpClientBuilder.build();
 ```

--- a/binding/httpcomponents/pom.xml
+++ b/binding/httpcomponents/pom.xml
@@ -4,8 +4,11 @@
     <groupId>io.tracee.binding</groupId>
     <artifactId>tracee-httpcomponents</artifactId>
     <packaging>bundle</packaging>
+	<properties>
+		<httpclient.version>4.4.1</httpclient.version>
+	</properties>
 
-    <parent>
+	<parent>
         <groupId>io.tracee</groupId>
         <artifactId>tracee-parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
@@ -29,7 +32,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.0.2</version>
+            <version>${httpclient.version}</version>
             <scope>provided</scope>
         </dependency>
 		<dependency>

--- a/binding/httpcomponents/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpInterceptorsIT.java
+++ b/binding/httpcomponents/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpInterceptorsIT.java
@@ -4,7 +4,8 @@ import io.tracee.Tracee;
 import io.tracee.TraceeConstants;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
@@ -31,9 +32,10 @@ public class TraceeHttpInterceptorsIT {
 	@Test
 	public void testWritesToServerAndParsesResponse() throws IOException {
 
-		DefaultHttpClient httpClient = new DefaultHttpClient();
-		httpClient.addRequestInterceptor(new TraceeHttpRequestInterceptor());
-		httpClient.addResponseInterceptor(new TraceeHttpResponseInterceptor());
+		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+		httpClientBuilder.addInterceptorLast(new TraceeHttpRequestInterceptor());
+		httpClientBuilder.addInterceptorFirst(new TraceeHttpResponseInterceptor());
+		CloseableHttpClient httpClient = httpClientBuilder.build();
 
 		HttpGet getMethod = new HttpGet(serverEndpoint);
 		Tracee.getBackend().put("before Request", "yip");


### PR DESCRIPTION
The used version of `httpcomponents` was antiquated and in the meanwhile the usage of the `HttpClient` has changed. With this PR a newer version of the httpcomponent library is used. I've adapted the test code and the documentation how the interceptors are added.

Regarding the interceptor order: I think it's great to be the last interceptor due request time but the first handling the response. So other request interceptors are able to add additional tracee values.