### PR TITLE
Throw IllegalArgumentException like MDC of slf4j instead of a NPE

### DIFF
--- a/core/src/main/java/io/tracee/backend/slf4j/Slf4jTraceeBackend.java
+++ b/core/src/main/java/io/tracee/backend/slf4j/Slf4jTraceeBackend.java
@@ -44,9 +44,9 @@ class Slf4jTraceeBackend extends BackendBase {
 	}
 
 	@Override
-	public void put(String key, String value) {
-		if (key == null) throw new NullPointerException("null keys are not allowed.");
-		if (value == null) throw new NullPointerException("null values are not allowed.");
+	public void put(String key, String value) throws IllegalArgumentException {
+		if (key == null) throw new IllegalArgumentException("null keys are not allowed.");
+		if (value == null) throw new IllegalArgumentException("null values are not allowed.");
 		final Set<String> registeredKeys = traceeKeys.get();
 		if (!registeredKeys.contains(key)) {
 			registeredKeys.add(key);
@@ -55,8 +55,8 @@ class Slf4jTraceeBackend extends BackendBase {
 	}
 
 	@Override
-	public void remove(String key) {
-		if (key == null) throw new NullPointerException("null keys are not allowed.");
+	public void remove(String key) throws IllegalArgumentException {
+		if (key == null) throw new IllegalArgumentException("null keys are not allowed.");
 		if (traceeKeys.get().remove(key)) {
 			MDC.remove(key);
 		}


### PR DESCRIPTION
Look into the MDC class of SLF4J: The `IllegalArgumentException` is also an unchecked exception but they promote the exception on API level by adding `throws IllegalArgumentException`.

Some static code analytic tools doesn't like a manual thrown NPE, so why not replace the NPE with the `IllegalArgumentException`?