### PR TITLE
add new module for httpcomponents 5

### DIFF
--- a/binding/README.md
+++ b/binding/README.md
@@ -15,5 +15,6 @@
 | JMS                         | Producer: Use [tracee-jms](jms/)'s `TraceeMessageWriter.wrap` on your `MessageWriter` | MDB: Use [trace-jms](jms/)'s `TraceeMessageListener` as EJB interceptor. |
 | ApacheHttpClient 3          | Use [tracee-httpclient](httpclient/)'s `TraceeHttpClientDecorator` | - |
 | ApacheHttpClient 4          | Use [tracee-components](httpcomponents/)'s `TraceeHttpRequestInterceptor` and `TraceeHttpResponseInterceptor` | - |
+| ApacheHttpClient 5          | Use [tracee-components5](httpcomponents5/)'s `TraceeHttpRequestInterceptor` and `TraceeHttpResponseInterceptor` | - |
 | Apache CXF                  | Use [tracee-cxf](cxf/)'s `TraceeCxfFeature` | Use [tracee-cxf](cxf/)'s `TraceeCxfFeature` |
 | Quartz Scheduler            | - | Use [tracee-quartz](quartz/)'s `TraceeJobListener` to generate context before the job starts |

--- a/binding/httpcomponents5/README.md
+++ b/binding/httpcomponents5/README.md
@@ -1,0 +1,32 @@
+> This document contains documentation for the `tracee-httpcomponents5` module.  Check the [TracEE main documentation](/README.md) to get started.
+
+# tracee-httpcomponents5
+
+Wrapper for [apache http client 5+](https://hc.apache.org/httpcomponents-client-5.0.x/)
+
+This module contains two interceptors:
+* __TraceeHttpRequestInterceptor__: Implements the `HttpRequestInterceptor` interface to add the tracee header to the request.
+* __TraceeHttpResponseInterceptor__: Implements the `HttpResponseInterceptor` to extract the tracee header from the response.
+
+## Installation
+
+```xml
+<dependencies>
+...
+    <dependency>
+        <groupId>io.tracee.binding</groupId>
+   		<artifactId>tracee-httpcomponents5</artifactId>
+        <version>${tracee.version}</version>
+    </dependency>
+...
+</dependencies>
+```
+
+Then add simply two interceptors to your HttpClient of the httpcomponents module:
+
+```java
+HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+httpClientBuilder.addInterceptorLast(new TraceeHttpRequestInterceptor());
+httpClientBuilder.addInterceptorFirst(new TraceeHttpResponseInterceptor());
+CloseableHttpClient httpClient = httpClientBuilder.build();
+```

--- a/binding/httpcomponents5/pom.xml
+++ b/binding/httpcomponents5/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.tracee.binding</groupId>
+	<artifactId>tracee-httpcomponents5</artifactId>
+	<packaging>bundle</packaging>
+	<properties>
+		<httpclient5.version>5.0-alpha1</httpclient5.version>
+	</properties>
+
+	<parent>
+		<groupId>io.tracee</groupId>
+		<artifactId>tracee-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<name>tracee-httpcomponents5</name>
+	<description>Please refer to https://github.com/tracee/tracee.</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.tracee</groupId>
+			<artifactId>tracee-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.tracee</groupId>
+			<artifactId>tracee-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<version>${httpclient5.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.tracee</groupId>
+			<artifactId>tracee-testhelper</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlet</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.tracee.backend</groupId>
+			<artifactId>tracee-threadlocal-store</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/binding/httpcomponents5/src/main/java/io/tracee/binding/httpcomponents/TraceeHttpRequestInterceptor.java
+++ b/binding/httpcomponents5/src/main/java/io/tracee/binding/httpcomponents/TraceeHttpRequestInterceptor.java
@@ -1,0 +1,45 @@
+package io.tracee.binding.httpcomponents;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.TraceeConstants;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
+import io.tracee.transport.HttpHeaderTransport;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+import java.util.Map;
+
+import static io.tracee.configuration.TraceeFilterConfiguration.Channel.OutgoingRequest;
+
+public class TraceeHttpRequestInterceptor implements HttpRequestInterceptor {
+
+	private final TraceeBackend backend;
+	private final HttpHeaderTransport transportSerialization;
+	private final String profile;
+
+	public TraceeHttpRequestInterceptor() {
+		this(Profile.DEFAULT);
+	}
+
+	public TraceeHttpRequestInterceptor(String profile) {
+		this(Tracee.getBackend(), profile);
+	}
+
+	TraceeHttpRequestInterceptor(TraceeBackend backend, String profile) {
+		this.backend = backend;
+		this.transportSerialization = new HttpHeaderTransport();
+		this.profile = profile;
+	}
+
+	@Override
+	public final void process(final HttpRequest httpRequest, final HttpContext httpContext) {
+		final TraceeFilterConfiguration filterConfiguration = backend.getConfiguration(profile);
+		if (!backend.isEmpty() && filterConfiguration.shouldProcessContext(OutgoingRequest)) {
+			final Map<String, String> filteredParams = filterConfiguration.filterDeniedParams(backend.copyToMap(), OutgoingRequest);
+			httpRequest.setHeader(TraceeConstants.TPIC_HEADER, transportSerialization.render(filteredParams));
+		}
+	}
+}

--- a/binding/httpcomponents5/src/main/java/io/tracee/binding/httpcomponents/TraceeHttpResponseInterceptor.java
+++ b/binding/httpcomponents5/src/main/java/io/tracee/binding/httpcomponents/TraceeHttpResponseInterceptor.java
@@ -1,0 +1,53 @@
+package io.tracee.binding.httpcomponents;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.TraceeConstants;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.configuration.TraceeFilterConfiguration.Profile;
+import io.tracee.transport.HttpHeaderTransport;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpResponseInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static io.tracee.configuration.TraceeFilterConfiguration.Channel.IncomingResponse;
+
+
+public class TraceeHttpResponseInterceptor implements HttpResponseInterceptor {
+
+	private final TraceeBackend backend;
+	private final HttpHeaderTransport transportSerialization;
+	private final String profile;
+
+	public TraceeHttpResponseInterceptor() {
+		this(Profile.DEFAULT);
+	}
+
+	public TraceeHttpResponseInterceptor(String profile) {
+		this(Tracee.getBackend(), profile);
+	}
+
+	TraceeHttpResponseInterceptor(TraceeBackend backend, String profile) {
+		this.backend = backend;
+		this.profile = profile;
+		transportSerialization = new HttpHeaderTransport();
+	}
+
+	@Override
+	public final void process(HttpResponse response, HttpContext context) {
+		final TraceeFilterConfiguration filterConfiguration = backend.getConfiguration(profile);
+		final Iterator<Header> headerIterator = response.headerIterator(TraceeConstants.TPIC_HEADER);
+		if (headerIterator != null && headerIterator.hasNext() && filterConfiguration.shouldProcessContext(IncomingResponse)) {
+			final List<String> stringTraceeHeaders = new ArrayList<>();
+			while (headerIterator.hasNext()) {
+				stringTraceeHeaders.add(headerIterator.next().getValue());
+			}
+			backend.putAll(filterConfiguration.filterDeniedParams(transportSerialization.parse(stringTraceeHeaders), IncomingResponse));
+		}
+	}
+}

--- a/binding/httpcomponents5/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpInterceptorsIT.java
+++ b/binding/httpcomponents5/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpInterceptorsIT.java
@@ -1,0 +1,74 @@
+package io.tracee.binding.httpcomponents;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeConstants;
+import org.apache.hc.client5.http.impl.sync.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.sync.HttpClientBuilder;
+import org.apache.hc.client5.http.methods.HttpGet;
+import org.apache.hc.core5.http.HttpResponse;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TraceeHttpInterceptorsIT {
+
+	private final Handler requestHandler = new AbstractHandler() {
+		@Override
+		public void handle(String s, Request request, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws IOException, ServletException {
+			final String incomingTraceeHeader = request.getHeader(TraceeConstants.TPIC_HEADER);
+
+			assertThat(incomingTraceeHeader, equalTo("before+Request=yip"));
+
+			httpServletResponse.setHeader(TraceeConstants.TPIC_HEADER, "responseFromServer=yes+Sir");
+			httpServletResponse.setStatus(HttpServletResponse.SC_NO_CONTENT);
+			request.setHandled(true);
+		}
+	};
+	private Server server;
+	private String serverEndpoint;
+
+	@Test
+	public void testWritesToServerAndParsesResponse() throws IOException {
+
+		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+		httpClientBuilder.addInterceptorLast(new TraceeHttpRequestInterceptor());
+		httpClientBuilder.addInterceptorFirst(new TraceeHttpResponseInterceptor());
+		CloseableHttpClient httpClient = httpClientBuilder.build();
+
+		HttpGet getMethod = new HttpGet(serverEndpoint);
+		Tracee.getBackend().put("before Request", "yip");
+		final HttpResponse response = httpClient.execute(getMethod);
+
+		assertThat(response.getStatusLine().getStatusCode(), equalTo(HttpServletResponse.SC_NO_CONTENT));
+		assertThat(Tracee.getBackend().get("responseFromServer"), equalTo("yes Sir"));
+	}
+
+	@Before
+	public void startJetty() throws Exception {
+		server = new Server(new InetSocketAddress("127.0.0.1", 0));
+		server.setHandler(requestHandler);
+		server.start();
+		serverEndpoint = "http://" + server.getConnectors()[0].getName();
+	}
+
+	@After
+	public void stopJetty() throws Exception {
+		if (server != null) {
+			server.stop();
+			server.join();
+		}
+	}
+}

--- a/binding/httpcomponents5/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpRequestInterceptorTest.java
+++ b/binding/httpcomponents5/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpRequestInterceptorTest.java
@@ -1,0 +1,53 @@
+package io.tracee.binding.httpcomponents;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.TraceeConstants;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.testhelper.FieldAccessUtil;
+import io.tracee.testhelper.SimpleTraceeBackend;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class TraceeHttpRequestInterceptorTest {
+
+	private final SimpleTraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+	private final TraceeHttpRequestInterceptor unit = new TraceeHttpRequestInterceptor(backend, null);
+
+	@Test
+	public void testRequestInterceptorWritesTraceeContextToRequestHeader() throws Exception {
+		final HttpRequest httpRequest = new BasicHttpRequest("GET", "http://localhost/pew");
+
+		backend.put("foo", "bar");
+
+		unit.process(httpRequest, mock(HttpContext.class));
+
+		assertThat("HttpRequest contains TracEE Context Header", httpRequest.containsHeader(TraceeConstants.TPIC_HEADER), equalTo(true));
+		assertThat(httpRequest.getFirstHeader(TraceeConstants.TPIC_HEADER).getValue(), equalTo("foo=bar"));
+	}
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeHttpRequestInterceptor interceptor = new TraceeHttpRequestInterceptor();
+		assertThat((String) FieldAccessUtil.getFieldVal(interceptor, "profile"), is(TraceeFilterConfiguration.Profile.DEFAULT));
+	}
+
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeHttpRequestInterceptor interceptor = new TraceeHttpRequestInterceptor();
+		assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(interceptor, "backend"), is(Tracee.getBackend()));
+	}
+
+	@Test
+	public void constructorStoresProfileNameInternal() {
+		final TraceeHttpRequestInterceptor interceptor = new TraceeHttpRequestInterceptor("testProf");
+		assertThat((String) FieldAccessUtil.getFieldVal(interceptor, "profile"), is("testProf"));
+	}
+}

--- a/binding/httpcomponents5/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpResponseInterceptorTest.java
+++ b/binding/httpcomponents5/src/test/java/io/tracee/binding/httpcomponents/TraceeHttpResponseInterceptorTest.java
@@ -1,0 +1,51 @@
+package io.tracee.binding.httpcomponents;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.TraceeConstants;
+import io.tracee.configuration.TraceeFilterConfiguration;
+import io.tracee.testhelper.FieldAccessUtil;
+import io.tracee.testhelper.SimpleTraceeBackend;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.message.BasicStatusLine;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class TraceeHttpResponseInterceptorTest {
+
+	private final SimpleTraceeBackend backend = SimpleTraceeBackend.createNonLoggingAllPermittingBackend();
+	private final TraceeHttpResponseInterceptor unit = new TraceeHttpResponseInterceptor(backend, null);
+
+	@Test
+	public void testResponseInterceptorParsesHttpHeaderToBackend() throws Exception {
+		final HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 404, "not found"));
+		httpResponse.setHeader(TraceeConstants.TPIC_HEADER, "foobi=bar");
+		unit.process(httpResponse, mock(HttpContext.class));
+		assertThat(backend.get("foobi"), equalTo("bar"));
+	}
+
+	@Test
+	public void defaultConstructorUsesDefaultProfile() {
+		final TraceeHttpResponseInterceptor injector = new TraceeHttpResponseInterceptor();
+		assertThat((String) FieldAccessUtil.getFieldVal(injector, "profile"), is(TraceeFilterConfiguration.Profile.DEFAULT));
+	}
+
+	@Test
+	public void defaultConstructorUsesTraceeBackend() {
+		final TraceeHttpResponseInterceptor injector = new TraceeHttpResponseInterceptor();
+		assertThat((TraceeBackend) FieldAccessUtil.getFieldVal(injector, "backend"), is(Tracee.getBackend()));
+	}
+
+	@Test
+	public void constructorStoresProfileNameInternal() {
+		final TraceeHttpResponseInterceptor injector = new TraceeHttpResponseInterceptor("testProf");
+		assertThat((String) FieldAccessUtil.getFieldVal(injector, "profile"), is("testProf"));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <!-- outgoing filters -->
         <module>binding/httpclient</module>
         <module>binding/httpcomponents</module>
+        <module>binding/httpcomponents5</module>
         <module>binding/springhttpclient</module>
 
         <!-- bidi filters -->


### PR DESCRIPTION
The alpha1 of [Apache HttpComponents 5](https://hc.apache.org/httpcomponents-client-5.0.x/index.html) has been released in January 2016. The new version of the library has a new package structure and a different maven identifier so our module for httpcomponents 4 doesn't fit.

WDYT?