### PR TITLE
Fixes #168: Change JMS header (Tracee 2.0)

### DIFF
--- a/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageListenerAndProducerIT.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageListenerAndProducerIT.java
@@ -2,6 +2,7 @@ package io.tracee.binding.jms;
 
 import io.tracee.Tracee;
 import io.tracee.TraceeConstants;
+import io.tracee.transport.HttpHeaderTransport;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -21,6 +22,7 @@ import javax.jms.TextMessage;
 import javax.naming.NamingException;
 import java.util.Map;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -72,7 +74,8 @@ public class TraceeMessageListenerAndProducerIT {
 
 				assertThat("response within 1 second", response, notNullValue());
 				assertThat(response.getText(), equalTo("foo"));
-				final Map<String, String> traceeContext = (Map<String, String>) response.getObjectProperty(TraceeConstants.TPIC_HEADER);
+				final String traceeContextAsString = response.getStringProperty(TraceeConstants.TPIC_HEADER);
+				final Map<String, String> traceeContext = new HttpHeaderTransport().parse(singletonList(traceeContextAsString));
 				assertThat(traceeContext, Matchers.hasEntry("foo", "bar"));
 			} finally {
 				session.close();

--- a/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageProducerTest.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageProducerTest.java
@@ -3,6 +3,7 @@ package io.tracee.binding.jms;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
 import io.tracee.testhelper.SimpleTraceeBackend;
+import io.tracee.transport.HttpHeaderTransport;
 import org.junit.Test;
 
 import javax.jms.DeliveryMode;
@@ -11,14 +12,18 @@ import javax.jms.Message;
 import javax.jms.MessageProducer;
 import java.util.Collections;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TraceeMessageProducerTest {
+
+	private final HttpHeaderTransport httpHeaderTransport = new HttpHeaderTransport();
 
 	private final TraceeBackend backend = spy(SimpleTraceeBackend.createNonLoggingAllPermittingBackend());
 	private final MessageProducer messageProducer = mock(MessageProducer.class);
@@ -29,7 +34,8 @@ public class TraceeMessageProducerTest {
 	public void testWriteTraceeContextToMessage() throws Exception {
 		backend.put("random", "entry");
 		unit.writeTraceeContextToMessage(message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), eq(Collections.singletonMap("random", "entry")));
+		final String renderedTpic = httpHeaderTransport.render(Collections.singletonMap("random", "entry"));
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), eq(renderedTpic));
 	}
 
 	@Test
@@ -43,7 +49,7 @@ public class TraceeMessageProducerTest {
 	public void sendMessageShouldAddContextAndDelegate() throws Exception {
 		backend.put("random", "entry");
 		unit.send(message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message);
 	}
 
@@ -52,7 +58,7 @@ public class TraceeMessageProducerTest {
 		backend.put("random", "entry");
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message);
 	}
 
@@ -60,7 +66,7 @@ public class TraceeMessageProducerTest {
 	public void sendMessageWithDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		backend.put("random", "entry");
 		unit.send(message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
@@ -69,7 +75,7 @@ public class TraceeMessageProducerTest {
 		backend.put("random", "entry");
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
@@ -99,5 +105,16 @@ public class TraceeMessageProducerTest {
 		verify(messageProducer).getDestination();
 		unit.close();
 		verify(messageProducer).close();
+	}
+
+	/**
+	 *
+	 * @see <a href="https://github.com/tracee/tracee/issues/168">TracEE Issue 168</a>
+	 */
+	@Test
+	public void writeContextWithoutUsingObjectMethods() throws Exception {
+		backend.put("random", "entry");
+		unit.send(message);
+		verify(message, never()).setObjectProperty(anyString(), any());
 	}
 }

--- a/binding/jms/src/test/java/io/tracee/binding/jms/TraceeQueueSenderTest.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TraceeQueueSenderTest.java
@@ -35,21 +35,21 @@ public class TraceeQueueSenderTest {
 	@Test
 	public void sendQueueShouldAddContextAndDelegate() throws Exception {
 		unit.send(queue, message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(queueSender).send(queue, message);
 	}
 
 	@Test
 	public void sendQueueWithExtendParametersShouldAddContextAndDelegate() throws Exception {
 		unit.send(queue, message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(queueSender).send(queue, message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
 	@Test
 	public void sendMessageShouldAddContextAndDelegate() throws Exception {
 		unit.send(message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message);
 	}
 
@@ -57,14 +57,14 @@ public class TraceeQueueSenderTest {
 	public void sendMessageWithDestinationShouldAddContextAndDelegate() throws Exception {
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message);
 	}
 
 	@Test
 	public void sendMessageWithDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		unit.send(message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
@@ -72,7 +72,7 @@ public class TraceeQueueSenderTest {
 	public void sendMessageWithDestinationAndDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 

--- a/binding/jms/src/test/java/io/tracee/binding/jms/TraceeTopicPublisherTest.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TraceeTopicPublisherTest.java
@@ -34,7 +34,7 @@ public class TraceeTopicPublisherTest {
 	@Test
 	public void publishMessageShouldAddContextAndDelegate() throws Exception {
 		unit.publish(message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(topicPublisher).publish(message);
 	}
 
@@ -42,14 +42,14 @@ public class TraceeTopicPublisherTest {
 	public void publishMessageWithTopicShouldAddContextAndDelegate() throws Exception {
 		final Topic topic = mock(Topic.class);
 		unit.publish(topic, message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(topicPublisher).publish(topic, message);
 	}
 
 	@Test
 	public void publishMessageWithDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		unit.publish(message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(topicPublisher).publish(message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
@@ -57,14 +57,14 @@ public class TraceeTopicPublisherTest {
 	public void publishMessageWithTopicAndDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		final Topic topic = mock(Topic.class);
 		unit.publish(topic, message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(topicPublisher).publish(topic, message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
 	@Test
 	public void sendMessageShouldAddContextAndDelegate() throws Exception {
 		unit.send(message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message);
 	}
 
@@ -72,14 +72,14 @@ public class TraceeTopicPublisherTest {
 	public void sendMessageWithDestinationShouldAddContextAndDelegate() throws Exception {
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message);
 	}
 
 	@Test
 	public void sendMessageWithDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		unit.send(message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
@@ -87,7 +87,7 @@ public class TraceeTopicPublisherTest {
 	public void sendMessageWithDestinationAndDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 


### PR DESCRIPTION
Websphere 12c doesn't allow Map as JMS header payload. Fix: We render the TPIC as string.