### PR TITLE
Fixes #168: Change JMS header (Tracee 1.x)

### DIFF
--- a/binding/jms/src/main/java/io/tracee/binding/jms/TraceeMessageListener.java
+++ b/binding/jms/src/main/java/io/tracee/binding/jms/TraceeMessageListener.java
@@ -4,6 +4,7 @@ import io.tracee.Tracee;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
 import io.tracee.Utilities;
+import io.tracee.transport.HttpHeaderTransport;
 
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.InvocationContext;
@@ -13,6 +14,7 @@ import java.lang.reflect.Method;
 import java.util.Map;
 
 import static io.tracee.configuration.TraceeFilterConfiguration.Channel.AsyncProcess;
+import static java.util.Collections.singletonList;
 
 /**
  * EJB interceptor that parses a TracEE context from message properties and cleans it after message processing.
@@ -21,8 +23,11 @@ public final class TraceeMessageListener {
 
 	private final TraceeBackend backend;
 
+	private final HttpHeaderTransport httpHeaderSerialization;
+
 	TraceeMessageListener(TraceeBackend backend) {
 		this.backend = backend;
+		this.httpHeaderSerialization = new HttpHeaderTransport();
 	}
 
 	@SuppressWarnings("unused")
@@ -49,9 +54,9 @@ public final class TraceeMessageListener {
     public void beforeProcessing(final Message message) throws JMSException {
 
 		if (backend.getConfiguration().shouldProcessContext(AsyncProcess)) {
-			final Object encodedTraceeContext = message.getObjectProperty(TraceeConstants.TPIC_HEADER);
+			final String encodedTraceeContext = message.getStringProperty(TraceeConstants.TPIC_HEADER);
 			if (encodedTraceeContext != null) {
-				final Map<String, String> contextFromMessage = (Map<String, String>) encodedTraceeContext;
+				final Map<String, String> contextFromMessage = httpHeaderSerialization.parse(singletonList(encodedTraceeContext));
 				backend.putAll(backend.getConfiguration().filterDeniedParams(contextFromMessage, AsyncProcess));
 			}
 		}

--- a/binding/jms/src/main/java/io/tracee/binding/jms/TraceeMessageProducer.java
+++ b/binding/jms/src/main/java/io/tracee/binding/jms/TraceeMessageProducer.java
@@ -3,6 +3,7 @@ package io.tracee.binding.jms;
 import io.tracee.Tracee;
 import io.tracee.TraceeBackend;
 import io.tracee.TraceeConstants;
+import io.tracee.transport.HttpHeaderTransport;
 
 import javax.jms.Destination;
 import javax.jms.JMSException;
@@ -14,18 +15,20 @@ import static io.tracee.configuration.TraceeFilterConfiguration.Channel.AsyncDis
 
 public class TraceeMessageProducer implements MessageProducer {
 
-
-    private final MessageProducer delegate;
+	private final MessageProducer delegate;
 	private final TraceeBackend backend;
+	private final HttpHeaderTransport httpHeaderSerialization;
 
     TraceeMessageProducer(MessageProducer delegate, TraceeBackend backend) {
         this.delegate = delegate;
 		this.backend = backend;
+		this.httpHeaderSerialization = new HttpHeaderTransport();
 	}
 
 	public TraceeMessageProducer(MessageProducer delegate) {
 		this.delegate = delegate;
 		this.backend = Tracee.getBackend();
+		this.httpHeaderSerialization = new HttpHeaderTransport();
 	}
 
     /**
@@ -36,7 +39,9 @@ public class TraceeMessageProducer implements MessageProducer {
 
 		if (!backend.isEmpty() && backend.getConfiguration().shouldProcessContext(AsyncDispatch)) {
 			final Map<String, String> filteredContext = backend.getConfiguration().filterDeniedParams(backend.copyToMap(), AsyncDispatch);
-			message.setObjectProperty(TraceeConstants.TPIC_HEADER, filteredContext);
+			final String contextAsString = httpHeaderSerialization.render(filteredContext);
+
+			message.setStringProperty(TraceeConstants.TPIC_HEADER, contextAsString);
 		}
     }
 

--- a/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageListenerAndProducerIT.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TraceeMessageListenerAndProducerIT.java
@@ -2,6 +2,7 @@ package io.tracee.binding.jms;
 
 import io.tracee.Tracee;
 import io.tracee.TraceeConstants;
+import io.tracee.transport.HttpHeaderTransport;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -13,6 +14,7 @@ import javax.jms.*;
 import javax.naming.NamingException;
 import java.util.Map;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -64,7 +66,8 @@ public class TraceeMessageListenerAndProducerIT {
 
 				assertThat("response within 1 second", response, notNullValue());
 				assertThat(response.getText(), equalTo("foo"));
-				final Map<String, String> traceeContext = (Map<String, String>) response.getObjectProperty(TraceeConstants.TPIC_HEADER);
+				final String traceeContextAsString = response.getStringProperty(TraceeConstants.TPIC_HEADER);
+				final Map<String, String> traceeContext = new HttpHeaderTransport().parse(singletonList(traceeContextAsString));
 				assertThat(traceeContext, Matchers.hasEntry("foo", "bar"));
 			} finally {
 				session.close();

--- a/binding/jms/src/test/java/io/tracee/binding/jms/TraceeQueueSenderTest.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TraceeQueueSenderTest.java
@@ -35,21 +35,21 @@ public class TraceeQueueSenderTest {
 	@Test
 	public void sendQueueShouldAddContextAndDelegate() throws Exception {
 		unit.send(queue, message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(queueSender).send(queue, message);
 	}
 
 	@Test
 	public void sendQueueWithExtendParametersShouldAddContextAndDelegate() throws Exception {
 		unit.send(queue, message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(queueSender).send(queue, message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
 	@Test
 	public void sendMessageShouldAddContextAndDelegate() throws Exception {
 		unit.send(message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message);
 	}
 
@@ -57,14 +57,14 @@ public class TraceeQueueSenderTest {
 	public void sendMessageWithDestinationShouldAddContextAndDelegate() throws Exception {
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message);
 	}
 
 	@Test
 	public void sendMessageWithDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		unit.send(message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
@@ -72,7 +72,7 @@ public class TraceeQueueSenderTest {
 	public void sendMessageWithDestinationAndDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 

--- a/binding/jms/src/test/java/io/tracee/binding/jms/TraceeTopicPublisherTest.java
+++ b/binding/jms/src/test/java/io/tracee/binding/jms/TraceeTopicPublisherTest.java
@@ -34,7 +34,7 @@ public class TraceeTopicPublisherTest {
 	@Test
 	public void publishMessageShouldAddContextAndDelegate() throws Exception {
 		unit.publish(message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(topicPublisher).publish(message);
 	}
 
@@ -42,14 +42,14 @@ public class TraceeTopicPublisherTest {
 	public void publishMessageWithTopicShouldAddContextAndDelegate() throws Exception {
 		final Topic topic = mock(Topic.class);
 		unit.publish(topic, message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(topicPublisher).publish(topic, message);
 	}
 
 	@Test
 	public void publishMessageWithDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		unit.publish(message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(topicPublisher).publish(message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
@@ -57,14 +57,14 @@ public class TraceeTopicPublisherTest {
 	public void publishMessageWithTopicAndDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		final Topic topic = mock(Topic.class);
 		unit.publish(topic, message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(topicPublisher).publish(topic, message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
 	@Test
 	public void sendMessageShouldAddContextAndDelegate() throws Exception {
 		unit.send(message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message);
 	}
 
@@ -72,14 +72,14 @@ public class TraceeTopicPublisherTest {
 	public void sendMessageWithDestinationShouldAddContextAndDelegate() throws Exception {
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message);
 	}
 
 	@Test
 	public void sendMessageWithDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		unit.send(message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 
@@ -87,7 +87,7 @@ public class TraceeTopicPublisherTest {
 	public void sendMessageWithDestinationAndDeliveryModeAndPriorityAndTTLShouldAddContextAndDelegate() throws Exception {
 		final Destination destination = mock(Destination.class);
 		unit.send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
-		verify(message).setObjectProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
+		verify(message).setStringProperty(eq(TraceeConstants.TPIC_HEADER), anyString());
 		verify(messageProducer).send(destination, message, DeliveryMode.PERSISTENT, 5, 100);
 	}
 


### PR DESCRIPTION
Websphere 12c doesn't allow Map as JMS header payload. Fix: We render the TPIC as string.

(cherry picked from commit c7c0a64)